### PR TITLE
Add API bridge for voice check-in assessment

### DIFF
--- a/src/app/api/voice-check-in/route.ts
+++ b/src/app/api/voice-check-in/route.ts
@@ -1,0 +1,37 @@
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+import type { NextRequest } from "next/server";
+
+import { assessVoiceCheckIn } from "@/ai/flows/voice-check-in-assessment";
+
+export async function POST(req: NextRequest) {
+  try {
+    const body = await req.json();
+    const { transcribedSpeech, previousVoiceMessages } = body ?? {};
+
+    if (typeof transcribedSpeech !== "string") {
+      return Response.json(
+        { error: "transcribedSpeech must be a string" },
+        { status: 400 },
+      );
+    }
+
+    if (!Array.isArray(previousVoiceMessages) || previousVoiceMessages.some((msg) => typeof msg !== "string")) {
+      return Response.json(
+        { error: "previousVoiceMessages must be an array of strings" },
+        { status: 400 },
+      );
+    }
+
+    const result = await assessVoiceCheckIn({
+      transcribedSpeech,
+      previousVoiceMessages,
+    });
+
+    return Response.json(result);
+  } catch (error) {
+    console.error("Voice check-in assessment failed:", error);
+    return Response.json({ error: "Failed to assess voice check-in." }, { status: 500 });
+  }
+}

--- a/src/components/voice-check-in.tsx
+++ b/src/components/voice-check-in.tsx
@@ -11,10 +11,7 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
-import {
-  assessVoiceCheckIn,
-  type AssessVoiceCheckInOutput,
-} from "@/ai/flows/voice-check-in-assessment";
+import type { AssessVoiceCheckInOutput } from "@/ai/flows/voice-check-in-assessment";
 import { useToast } from "@/hooks/use-toast";
 
 /**
@@ -104,10 +101,22 @@ export function VoiceCheckIn() {
       try {
         // Send to your AI function
         const previousMessages = getPreviousMessages();
-        const result = await assessVoiceCheckIn({
-          transcribedSpeech: currentTranscript,
-          previousVoiceMessages: previousMessages,
+        const response = await fetch("/api/voice-check-in", {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({
+            transcribedSpeech: currentTranscript,
+            previousVoiceMessages,
+          }),
         });
+
+        if (!response.ok) {
+          throw new Error(`Voice assessment failed with status ${response.status}`);
+        }
+
+        const result: AssessVoiceCheckInOutput = await response.json();
         setAssessment(result);
 
         toast({


### PR DESCRIPTION
## Summary
- add a server-side API route that proxies voice check-in requests to the Genkit flow
- update the voice check-in component to call the new endpoint instead of importing the server action directly

## Testing
- npm run lint *(fails: existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68e1b71998688323b3777301d2cd89de