### PR TITLE
Guard notification permission requests

### DIFF
--- a/src/lib/devices.ts
+++ b/src/lib/devices.ts
@@ -80,6 +80,14 @@ export async function registerDevice(uid: string, role: 'primary' | 'emergency')
     if (!messaging) return;
 
     // Ask for notification permission (shows a browser prompt)
+    if (
+      typeof Notification === 'undefined' ||
+      typeof Notification.requestPermission !== 'function'
+    ) {
+      console.warn('Web Notifications API is unavailable in this environment.');
+      return;
+    }
+
     const permission = await Notification.requestPermission();
     if (permission !== 'granted') {
       console.warn('Notification permission not granted.');

--- a/src/lib/useFcmToken.ts
+++ b/src/lib/useFcmToken.ts
@@ -71,6 +71,14 @@ export async function registerDevice(uid: string, role?: 'primary' | 'emergency'
     const messaging = (await messagingPromise) as Messaging | null;
     if (!messaging) return;
 
+    if (
+      typeof Notification === 'undefined' ||
+      typeof Notification.requestPermission !== 'function'
+    ) {
+      console.warn('Web Notifications API is unavailable in this environment.');
+      return;
+    }
+
     const permission = await Notification.requestPermission();
     if (permission !== 'granted') {
       console.warn('Notification permission not granted.');


### PR DESCRIPTION
## Summary
- prevent registerDevice helpers from calling Notification.requestPermission when the API is unavailable
- warn users when the browser lacks Notification.requestPermission support to avoid runtime errors

## Testing
- npm run lint *(fails: pre-existing lint violations across unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68e1c3890dc0832396ed5d13e31b4ed6