### PR TITLE
Add optional check-in callback to voice component

### DIFF
--- a/src/components/voice-check-in.tsx
+++ b/src/components/voice-check-in.tsx
@@ -21,7 +21,11 @@ import { useToast } from "@/hooks/use-toast";
  * - Sends the transcript to your AI function to assess anomalies
  * - Presents a simple status + explanation
  */
-export function VoiceCheckIn() {
+export interface VoiceCheckInProps {
+  onCheckIn?: () => void | Promise<void>;
+}
+
+export function VoiceCheckIn({ onCheckIn }: VoiceCheckInProps) {
   /** UI/state flags */
   const [isListening, setIsListening] = useState(false);       // mic actively capturing speech
   const [isProcessing, setIsProcessing] = useState(false);     // AI is running
@@ -123,6 +127,14 @@ export function VoiceCheckIn() {
           title: "Check-in Complete",
           description: "Your voice check-in has been processed.",
         });
+
+        if (onCheckIn) {
+          try {
+            await onCheckIn();
+          } catch (callbackError) {
+            console.error("Voice check-in callback failed:", callbackError);
+          }
+        }
       } catch (error) {
         console.error("AI assessment failed:", error);
         toast({


### PR DESCRIPTION
## Summary
- add an exported `VoiceCheckInProps` interface with an optional `onCheckIn` callback
- call the optional callback after a successful voice check-in while guarding against callback failures

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e1c871468c8323b64d76739a24dd34