### PR TITLE
Fix voice check-in payload handling and interval options

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -60,6 +60,8 @@ type Status = "safe" | "missed" | "unknown";
 // helper to compute minutes-since-epoch
 const toEpochMinutes = (ms: number) => Math.floor(ms / 60000);
 
+const HOURS_OPTIONS = [1, 2, 3, 6, 10, 12, 18, 24] as const;
+
 export default function DashboardPage() {
   const router = useRouter();
   const { toast } = useToast();
@@ -292,10 +294,10 @@ export default function DashboardPage() {
   };
 
   // Update interval + recompute dueAtMin
-  const HOURS_OPTIONS = [1, 2, 3, 6, 10, 12, 18, 24] as const;
   const selectedHours = useMemo(() => {
     const h = Math.round(intervalMinutes / 60);
-    return HOURS_OPTIONS.includes(h as any) ? String(h) : "12";
+    const isValidOption = HOURS_OPTIONS.some((option) => option === h);
+    return isValidOption ? String(h) : "12";
   }, [intervalMinutes]);
 
   const handleIntervalChange = async (value: string) => {

--- a/src/components/voice-check-in.tsx
+++ b/src/components/voice-check-in.tsx
@@ -104,7 +104,7 @@ export function VoiceCheckIn({ onCheckIn }: VoiceCheckInProps) {
       setIsProcessing(true);
       try {
         // Send to your AI function
-        const previousMessages = getPreviousMessages();
+        const previousVoiceMessages = getPreviousMessages();
         const response = await fetch("/api/voice-check-in", {
           method: "POST",
           headers: {


### PR DESCRIPTION
## Summary
- ensure the voice check-in component sends the stored previous voice messages when requesting an assessment
- hoist the dashboard check-in interval options to module scope and make the selection logic robust

## Testing
- npm run lint *(fails: existing lint issues in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68e1cbd735e08323995dfc0df852f6ac