### PR TITLE
Add optional location sharing during alerts

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -525,7 +525,9 @@ export default function DashboardPage() {
     contactName: "Mom",
     holdToActivateMs: 1500,
     confirm: true,
-    onActivate: () => shareLocation("sos"),
+    onActivate: async () => {
+      await shareLocation("sos");
+    },
   });
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- add consent-managed location sharing logic on the primary dashboard, including location capture on SOS and escalations
- surface the location sharing state to emergency contacts with map gating and updated messaging
- allow the SOS dialer hook to run a callback before launching the call so we can push location updates

## Testing
- npm run lint *(fails: pre-existing lint issues such as react/no-unescaped-entities and @typescript-eslint/no-explicit-any)*

------
https://chatgpt.com/codex/tasks/task_e_68e1f27e595883238feda66769a7ce41