### PR TITLE
Restrict dashboard location sharing to SOS events

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -346,13 +346,21 @@ export default function DashboardPage() {
     });
 
     lastLocationShareRef.current = null;
+    hasAutoClearedOnActiveRef.current = false;
     setLocationShareReason(null);
     setLocationSharedAt(null);
   }, []);
 
   const shareLocation = useCallback(
     async (reason: LocationShareReason) => {
-      if (locationSharing !== true) return false;
+      if (locationSharing === false) {
+        toast({
+          title: "Location sharing disabled",
+          description: "Enable location sharing first so we can send your SOS location.",
+          variant: "destructive",
+        });
+        return false;
+      }
 
       const ref = userRef.current;
       if (!ref) return false;
@@ -393,6 +401,7 @@ export default function DashboardPage() {
         });
 
         lastLocationShareRef.current = { reason, ts: Date.now() };
+        hasAutoClearedOnActiveRef.current = false;
         setLocationShareReason(reason);
         setLocationSharedAt(new Date());
 


### PR DESCRIPTION
## Summary
- stop automatically sharing a user location when an escalation begins so SOS is the only trigger
- track active dashboard sessions and clear any previously shared location data as soon as the user opens the app

## Testing
- npm run lint *(fails: existing lint violations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68e9b8585c0c83239346d26171fa3101