### PR TITLE
Ensure SOS call triggers dial and location share

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -367,7 +367,12 @@ export default function DashboardPage() {
       }
 
       const last = lastLocationShareRef.current;
-      if (last && last.reason === reason && Date.now() - last.ts < LOCATION_SHARE_COOLDOWN_MS) {
+      const shouldThrottle =
+        reason !== "sos" &&
+        last &&
+        last.reason === reason &&
+        Date.now() - last.ts < LOCATION_SHARE_COOLDOWN_MS;
+      if (shouldThrottle) {
         return true;
       }
 

--- a/src/hooks/useSosDialer.ts
+++ b/src/hooks/useSosDialer.ts
@@ -38,18 +38,16 @@ export function useSosDialer(opts?: {
     return () => cancelAnimationFrame(rafId);
   }, [holding, holdToActivateMs]);
 
-  const completeActivation = async () => {
+  const completeActivation = () => {
     const label = contactName ? ` ${contactName}` : "";
     if (confirm && !window.confirm(`Call${label}?`)) {
       return;
     }
 
     if (typeof onActivate === "function") {
-      try {
-        await onActivate();
-      } catch (error) {
+      Promise.resolve(onActivate()).catch((error) => {
         console.error("useSosDialer onActivate failed", error);
-      }
+      });
     }
 
     const a = document.createElement("a");


### PR DESCRIPTION
## Summary
- ensure SOS-triggered location shares are never throttled so contacts receive each alert
- allow the SOS dialer to fire the phone call immediately while SOS side effects run asynchronously

## Testing
- npm run lint *(fails: existing lint violations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68e9c0d6fb6c8323af0dca6b42d78d4b