### PR TITLE
Configure SOS dialing per country and Telnyx call

### DIFF
--- a/src/constants/emergency-services.ts
+++ b/src/constants/emergency-services.ts
@@ -1,0 +1,55 @@
+export const EMERGENCY_SERVICE_COUNTRY_VALUES = [
+  "US",
+  "CA",
+  "MX",
+  "BR",
+  "GB",
+  "EU",
+  "AU",
+  "NZ",
+  "IN",
+] as const;
+
+export type EmergencyServiceCountryCode =
+  (typeof EMERGENCY_SERVICE_COUNTRY_VALUES)[number];
+
+interface EmergencyServiceDetails {
+  label: string;
+  dial: string;
+}
+
+const EMERGENCY_SERVICE_DETAILS: Record<
+  EmergencyServiceCountryCode,
+  EmergencyServiceDetails
+> = {
+  US: { label: "United States / Canada", dial: "911" },
+  CA: { label: "Canada", dial: "911" },
+  MX: { label: "Mexico", dial: "911" },
+  BR: { label: "Brazil", dial: "190" },
+  GB: { label: "United Kingdom", dial: "999" },
+  EU: { label: "European Union", dial: "112" },
+  AU: { label: "Australia", dial: "000" },
+  NZ: { label: "New Zealand", dial: "111" },
+  IN: { label: "India", dial: "112" },
+};
+
+export const EMERGENCY_SERVICE_OPTIONS =
+  EMERGENCY_SERVICE_COUNTRY_VALUES.map((code) => ({
+    code,
+    ...EMERGENCY_SERVICE_DETAILS[code],
+  }));
+
+export const DEFAULT_EMERGENCY_SERVICE_COUNTRY: EmergencyServiceCountryCode = "US";
+
+export function getEmergencyService(
+  country?: string | null
+): EmergencyServiceDetails & { code: EmergencyServiceCountryCode } {
+  const normalized = (country || "").toUpperCase() as EmergencyServiceCountryCode;
+  if (EMERGENCY_SERVICE_DETAILS[normalized]) {
+    return { code: normalized, ...EMERGENCY_SERVICE_DETAILS[normalized] };
+  }
+  return {
+    code: DEFAULT_EMERGENCY_SERVICE_COUNTRY,
+    ...EMERGENCY_SERVICE_DETAILS[DEFAULT_EMERGENCY_SERVICE_COUNTRY],
+  };
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,6 +18,7 @@
         "name": "next"
       }
     ],
+    "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"]
     }


### PR DESCRIPTION
## Summary
- add a shared emergency service directory and extend emergency contact settings so users can pick their country
- persist the selected emergency service on the dashboard, update the SOS hold-to-call messaging, and dial Telnyx with the primary contact’s number
- display the configured emergency service alongside contact details for quick confirmation

## Testing
- npm run lint *(fails: repository already contains numerous pre-existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68e9d63404c4832380e27eb86254ada4