### PR TITLE
Collect and expose main user phone numbers

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -957,14 +957,17 @@ export default function DashboardPage() {
 
     setPhoneSaving(true);
     try {
-      const payload: Record<string, unknown> = { updatedAt: serverTimestamp() };
       if (sanitized) {
-        payload.phone = sanitized;
+        await updateDoc(userRef.current, {
+          phone: sanitized,
+          updatedAt: serverTimestamp(),
+        });
       } else {
-        payload.phone = deleteField();
+        await updateDoc(userRef.current, {
+          phone: deleteField(),
+          updatedAt: serverTimestamp(),
+        });
       }
-
-      await updateDoc(userRef.current, payload);
 
       setSavedPhone(sanitized);
       setPhoneDraft(sanitized);

--- a/src/app/emergency-dashboard/page.tsx
+++ b/src/app/emergency-dashboard/page.tsx
@@ -66,6 +66,7 @@ export type MainUserCard = {
   locationSharedAt?: Date | null;
   locationSharing?: boolean;
   colorClass: string;
+  phone?: string | null;
 };
 
 export type MainUserDoc = {
@@ -81,6 +82,7 @@ export type MainUserDoc = {
   locationSharing?: boolean;
   role?: string;
   dueAtMin?: number; // materialized next deadline (minutes since epoch)
+  phone?: string;
 };
 
 // ---------------------- Helpers ----------------------
@@ -313,6 +315,10 @@ export default function EmergencyDashboardPage() {
                   locationShareReason: shareReason,
                   locationSharedAt: sharedAt,
                   locationSharing: hasConsent,
+                  phone:
+                    typeof (userData as any)?.phone === "string"
+                      ? (userData as any).phone.trim()
+                      : null,
                 };
 
                 setMainUsers((prev) => {
@@ -468,6 +474,11 @@ export default function EmergencyDashboardPage() {
                       ? "Location will appear here if they trigger SOS or an escalation."
                       : "They have not granted location sharing, so no location is available."}
                   </p>
+                  <p className="text-sm text-muted-foreground">
+                    {p.phone
+                      ? `Call button dials ${p.phone}.`
+                      : "They haven't added a phone number yet."}
+                  </p>
 
                   <div className="relative h-40 w-full rounded-lg overflow-hidden border">
                     <Image
@@ -499,10 +510,22 @@ export default function EmergencyDashboardPage() {
                 </CardContent>
 
                 <CardFooter className="grid grid-cols-2 gap-2">
-                  <Button variant="outline">
-                    <Phone className="mr-2 h-4 w-4" />
-                    Call
-                  </Button>
+                  {p.phone ? (
+                    <Button asChild variant="outline">
+                      <a
+                        href={`tel:${p.phone.replace(/\s+/g, "")}`}
+                        aria-label={`Call ${p.name}`}
+                      >
+                        <Phone className="mr-2 h-4 w-4" />
+                        Call
+                      </a>
+                    </Button>
+                  ) : (
+                    <Button variant="outline" disabled title="No phone number on file">
+                      <Phone className="mr-2 h-4 w-4" />
+                      Call
+                    </Button>
+                  )}
                   <Button variant="outline">
                     <MessageSquare className="mr-2 h-4 w-4" />
                     Message

--- a/src/app/emergency-dashboard/page.tsx
+++ b/src/app/emergency-dashboard/page.tsx
@@ -50,6 +50,7 @@ import {
 // Push registration + roles
 import { registerDevice } from "@/lib/useFcmToken";
 import { normalizeRole } from "@/lib/roles";
+import { sanitizePhone } from "@/lib/phone";
 
 // ---------------------- Types ----------------------
 export type Status = "OK" | "Inactive" | "SOS";
@@ -303,6 +304,8 @@ export default function EmergencyDashboardPage() {
 
                 const locationString = shareReason ? userData?.location || "" : "";
 
+                const sanitizedPhone = sanitizePhone((userData as any)?.phone);
+
                 const updatedCard: MainUserCard = {
                   mainUserUid: mainUserId,
                   name: displayName || name,
@@ -315,10 +318,7 @@ export default function EmergencyDashboardPage() {
                   locationShareReason: shareReason,
                   locationSharedAt: sharedAt,
                   locationSharing: hasConsent,
-                  phone:
-                    typeof (userData as any)?.phone === "string"
-                      ? (userData as any).phone.trim()
-                      : null,
+                  phone: sanitizedPhone || null,
                 };
 
                 setMainUsers((prev) => {
@@ -512,10 +512,7 @@ export default function EmergencyDashboardPage() {
                 <CardFooter className="grid grid-cols-2 gap-2">
                   {p.phone ? (
                     <Button asChild variant="outline">
-                      <a
-                        href={`tel:${p.phone.replace(/\s+/g, "")}`}
-                        aria-label={`Call ${p.name}`}
-                      >
+                      <a href={`tel:${p.phone}`} aria-label={`Call ${p.name}`}>
                         <Phone className="mr-2 h-4 w-4" />
                         Call
                       </a>

--- a/src/app/emergency_contact/accept/page.tsx
+++ b/src/app/emergency_contact/accept/page.tsx
@@ -1,4 +1,4 @@
-// app/emergency-dashboard/page.tsx
+// app/emergency_contact/accept/page.tsx
 "use client";
 
 import Image from "next/image";
@@ -50,6 +50,7 @@ import {
 // Push registration + roles
 import { registerDevice } from "@/lib/useFcmToken";
 import { normalizeRole } from "@/lib/roles";
+import { sanitizePhone } from "@/lib/phone";
 
 // ---------------------- Types ----------------------
 export type Status = "OK" | "Inactive" | "SOS";
@@ -303,6 +304,8 @@ export default function EmergencyDashboardPage() {
 
                 const locationString = shareReason ? userData?.location || "" : "";
 
+                const sanitizedPhone = sanitizePhone((userData as any)?.phone);
+
                 const updatedCard: MainUserCard = {
                   mainUserUid: mainUserId,
                   name: displayName || name,
@@ -315,10 +318,7 @@ export default function EmergencyDashboardPage() {
                   locationShareReason: shareReason,
                   locationSharedAt: sharedAt,
                   locationSharing: hasConsent,
-                  phone:
-                    typeof (userData as any)?.phone === "string"
-                      ? (userData as any).phone.trim()
-                      : null,
+                  phone: sanitizedPhone || null,
                 };
 
                 setMainUsers((prev) => {
@@ -512,10 +512,7 @@ export default function EmergencyDashboardPage() {
                 <CardFooter className="grid grid-cols-2 gap-2">
                   {p.phone ? (
                     <Button asChild variant="outline">
-                      <a
-                        href={`tel:${p.phone.replace(/\s+/g, "")}`}
-                        aria-label={`Call ${p.name}`}
-                      >
+                      <a href={`tel:${p.phone}`} aria-label={`Call ${p.name}`}>
                         <Phone className="mr-2 h-4 w-4" />
                         Call
                       </a>

--- a/src/app/emergency_contact/accept/page.tsx
+++ b/src/app/emergency_contact/accept/page.tsx
@@ -66,6 +66,7 @@ export type MainUserCard = {
   locationSharedAt?: Date | null;
   locationSharing?: boolean;
   colorClass: string;
+  phone?: string | null;
 };
 
 export type MainUserDoc = {
@@ -81,6 +82,7 @@ export type MainUserDoc = {
   locationSharing?: boolean;
   role?: string;
   dueAtMin?: number; // materialized next deadline (minutes since epoch)
+  phone?: string;
 };
 
 // ---------------------- Helpers ----------------------
@@ -313,6 +315,10 @@ export default function EmergencyDashboardPage() {
                   locationShareReason: shareReason,
                   locationSharedAt: sharedAt,
                   locationSharing: hasConsent,
+                  phone:
+                    typeof (userData as any)?.phone === "string"
+                      ? (userData as any).phone.trim()
+                      : null,
                 };
 
                 setMainUsers((prev) => {
@@ -468,6 +474,11 @@ export default function EmergencyDashboardPage() {
                       ? "Location will appear here if they trigger SOS or an escalation."
                       : "They have not granted location sharing, so no location is available."}
                   </p>
+                  <p className="text-sm text-muted-foreground">
+                    {p.phone
+                      ? `Call button dials ${p.phone}.`
+                      : "They haven't added a phone number yet."}
+                  </p>
 
                   <div className="relative h-40 w-full rounded-lg overflow-hidden border">
                     <Image
@@ -499,10 +510,22 @@ export default function EmergencyDashboardPage() {
                 </CardContent>
 
                 <CardFooter className="grid grid-cols-2 gap-2">
-                  <Button variant="outline">
-                    <Phone className="mr-2 h-4 w-4" />
-                    Call
-                  </Button>
+                  {p.phone ? (
+                    <Button asChild variant="outline">
+                      <a
+                        href={`tel:${p.phone.replace(/\s+/g, "")}`}
+                        aria-label={`Call ${p.name}`}
+                      >
+                        <Phone className="mr-2 h-4 w-4" />
+                        Call
+                      </a>
+                    </Button>
+                  ) : (
+                    <Button variant="outline" disabled title="No phone number on file">
+                      <Phone className="mr-2 h-4 w-4" />
+                      Call
+                    </Button>
+                  )}
                   <Button variant="outline">
                     <MessageSquare className="mr-2 h-4 w-4" />
                     Message

--- a/src/lib/phone.ts
+++ b/src/lib/phone.ts
@@ -1,0 +1,26 @@
+export function sanitizePhone(raw: string | null | undefined): string {
+  if (typeof raw !== "string") {
+    return "";
+  }
+
+  const trimmed = raw.trim();
+  if (!trimmed) {
+    return "";
+  }
+
+  let normalized = trimmed.replace(/[^\d+]/g, "");
+  normalized = normalized.startsWith("+")
+    ? `+${normalized.slice(1).replace(/\+/g, "")}`
+    : normalized.replace(/\+/g, "");
+
+  return normalized;
+}
+
+export function isValidE164Phone(raw: string | null | undefined): boolean {
+  const sanitized = sanitizePhone(raw);
+  if (!sanitized) {
+    return false;
+  }
+
+  return /^\+[1-9]\d{7,14}$/.test(sanitized);
+}


### PR DESCRIPTION
## Summary
- collect a required mobile phone number during signup and store it on the user profile
- add an account card on the main dashboard so primary users can update their callback number later
- surface the saved number to emergency contacts and wire the Call action to a tel: link

## Testing
- npm run lint *(fails: next binary unavailable before installing dependencies)*
- npm install *(fails: registry returned 403 for dependency package)*

------
https://chatgpt.com/codex/tasks/task_e_68e9ed20b9d08323b91b75a5a5c0d0a1