### PR TITLE
Consolidate dashboard settings cards

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -44,6 +44,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import { Separator } from "@/components/ui/separator";
 import { useToast } from "@/hooks/use-toast";
 
 // icons
@@ -1096,32 +1097,6 @@ export default function DashboardPage() {
               </CardContent>
             </Card>
 
-            {/* Interval */}
-            <Card className="shadow-lg">
-              <CardHeader className="flex flex-row items-center justify-between">
-                <div>
-                  <CardTitle className="text-2xl font-headline">Set Interval</CardTitle>
-                  <CardDescription>Choose your check-in frequency.</CardDescription>
-                </div>
-                <Clock className="h-8 w-8 text-muted-foreground" />
-              </CardHeader>
-              <CardContent>
-                <Select onValueChange={handleIntervalChange} value={selectedHours}>
-                  <SelectTrigger className="w-full text-lg">
-                    <SelectValue placeholder="Select interval" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {HOURS_OPTIONS.map((h) => (
-                      <SelectItem key={h} value={String(h)}>{`Every ${h} hours`}</SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
-                <p className="mt-2 text-sm text-muted-foreground">
-                  Current interval: {Math.floor(intervalMinutes / 60)}h {intervalMinutes % 60}m
-                </p>
-              </CardContent>
-            </Card>
-
             {/* Status */}
             <Card className="shadow-lg">
               <CardHeader className="flex flex-row items-center justify-between">
@@ -1181,66 +1156,6 @@ export default function DashboardPage() {
               </CardContent>
             </Card>
 
-            {/* Location Sharing */}
-            <Card className="shadow-lg">
-              <CardHeader>
-                <CardTitle className="text-2xl font-headline">Location Sharing</CardTitle>
-                <CardDescription>Share your location only when an alert is active.</CardDescription>
-              </CardHeader>
-              <CardContent className="space-y-4 text-left">
-                <p className="text-sm text-muted-foreground">
-                  We only send your location when you press SOS or when an escalation begins.
-                </p>
-                <div className="flex items-center justify-between text-lg">
-                  <span className="font-semibold">Consent</span>
-                  <span
-                    className={`font-bold ${
-                      locationSharing === true
-                        ? "text-green-600"
-                        : locationSharing === false
-                        ? "text-destructive"
-                        : "text-muted-foreground"
-                    }`}
-                  >
-                    {locationSharing === null ? "—" : locationSharing ? "Enabled" : "Disabled"}
-                  </span>
-                </div>
-                {locationShareReason ? (
-                  <p className="text-sm text-muted-foreground">
-                    Last shared for {locationShareReason === "sos" ? "an SOS alert" : "an escalation"}
-                    {locationSharedAt ? ` (${formatWhen(locationSharedAt)})` : ""}.
-                  </p>
-                ) : (
-                  <p className="text-sm text-muted-foreground">
-                    {locationSharing === true
-                      ? "Your location stays hidden until an SOS alert or escalation occurs."
-                      : "Turn this on to optionally send your location during SOS alerts or escalations."}
-                  </p>
-                )}
-                {locationSharing ? (
-                  <div className="flex flex-col gap-2 sm:flex-row">
-                    <Button onClick={disableLocationSharing} disabled={locationMutationPending}>
-                      {locationMutationPending ? "Disabling…" : "Disable & Clear"}
-                    </Button>
-                    <Button
-                      variant="outline"
-                      onClick={handleClearSharedLocation}
-                      disabled={clearingLocation || locationMutationPending || !locationShareReason}
-                    >
-                      {clearingLocation ? "Clearing…" : "Clear last share"}
-                    </Button>
-                  </div>
-                ) : (
-                  <Button onClick={enableLocationSharing} disabled={locationMutationPending}>
-                    {locationMutationPending ? "Enabling…" : "Enable location sharing"}
-                  </Button>
-                )}
-                {sharingLocation && (
-                  <p className="text-xs text-muted-foreground">Sharing your current location…</p>
-                )}
-              </CardContent>
-            </Card>
-
             {/* Emergency Contacts */}
             <div className="md:col-span-2">
               <EmergencyContacts />
@@ -1250,43 +1165,139 @@ export default function DashboardPage() {
           {/* Right column */}
           <div className="lg:col-span-1 space-y-6">
             <Card className="p-4 shadow-lg">
-              <CardHeader>
-                <CardTitle className="text-2xl font-headline">Emergency Callback</CardTitle>
+              <CardHeader className="pb-4">
+                <CardTitle className="text-2xl font-headline">Your Settings</CardTitle>
                 <CardDescription>
-                  Emergency contacts tap “Call” to reach you at this number.
+                  Manage how you stay connected with your emergency contacts.
                 </CardDescription>
               </CardHeader>
-              <CardContent className="space-y-4">
-                <div className="space-y-2">
-                  <Label htmlFor="main-user-phone">Mobile phone</Label>
-                  <Input
-                    id="main-user-phone"
-                    placeholder="+15551234567"
-                    value={phoneDraft}
-                    onChange={(event) => setPhoneDraft(event.target.value)}
-                    disabled={phoneSaving}
-                    inputMode="tel"
-                  />
-                  <p className="text-xs text-muted-foreground">
-                    Include country code. We’ll auto-format for emergency contacts.
+              <CardContent className="space-y-6">
+                <section className="space-y-3">
+                  <div>
+                    <h3 className="text-lg font-semibold">Emergency Callback</h3>
+                    <p className="text-sm text-muted-foreground">
+                      Emergency contacts tap “Call” to reach you at this number.
+                    </p>
+                  </div>
+                  <div className="space-y-2">
+                    <Label htmlFor="main-user-phone">Mobile phone</Label>
+                    <Input
+                      id="main-user-phone"
+                      placeholder="+15551234567"
+                      value={phoneDraft}
+                      onChange={(event) => setPhoneDraft(event.target.value)}
+                      disabled={phoneSaving}
+                      inputMode="tel"
+                    />
+                    <p className="text-xs text-muted-foreground">
+                      Include country code. We’ll auto-format for emergency contacts.
+                    </p>
+                  </div>
+                  <div className="flex flex-col gap-2 sm:flex-row">
+                    <Button
+                      onClick={handlePhoneSave}
+                      disabled={phoneSaving || !phoneDirty}
+                      className="sm:flex-1"
+                    >
+                      {phoneSaving ? "Saving…" : "Save number"}
+                    </Button>
+                    <Button
+                      variant="outline"
+                      onClick={handlePhoneReset}
+                      disabled={phoneSaving || !phoneDirty}
+                    >
+                      Cancel
+                    </Button>
+                  </div>
+                </section>
+
+                <Separator />
+
+                <section className="space-y-3">
+                  <div className="flex items-center justify-between gap-4">
+                    <div>
+                      <h3 className="text-lg font-semibold">Set Interval</h3>
+                      <p className="text-sm text-muted-foreground">
+                        Choose your check-in frequency.
+                      </p>
+                    </div>
+                    <Clock className="h-6 w-6 text-muted-foreground" />
+                  </div>
+                  <Select onValueChange={handleIntervalChange} value={selectedHours}>
+                    <SelectTrigger className="w-full text-lg">
+                      <SelectValue placeholder="Select interval" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {HOURS_OPTIONS.map((h) => (
+                        <SelectItem key={h} value={String(h)}>{`Every ${h} hours`}</SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                  <p className="text-sm text-muted-foreground">
+                    Current interval: {Math.floor(intervalMinutes / 60)}h {intervalMinutes % 60}m
                   </p>
-                </div>
-                <div className="flex flex-col gap-2 sm:flex-row">
-                  <Button
-                    onClick={handlePhoneSave}
-                    disabled={phoneSaving || !phoneDirty}
-                    className="sm:flex-1"
-                  >
-                    {phoneSaving ? "Saving…" : "Save number"}
-                  </Button>
-                  <Button
-                    variant="outline"
-                    onClick={handlePhoneReset}
-                    disabled={phoneSaving || !phoneDirty}
-                  >
-                    Cancel
-                  </Button>
-                </div>
+                </section>
+
+                <Separator />
+
+                <section className="space-y-3">
+                  <div>
+                    <h3 className="text-lg font-semibold">Location Sharing</h3>
+                    <p className="text-sm text-muted-foreground">
+                      Share your location only when an alert is active.
+                    </p>
+                  </div>
+                  <p className="text-sm text-muted-foreground">
+                    We only send your location when you press SOS or when an escalation begins.
+                  </p>
+                  <div className="flex items-center justify-between text-lg">
+                    <span className="font-semibold">Consent</span>
+                    <span
+                      className={`font-bold ${
+                        locationSharing === true
+                          ? "text-green-600"
+                          : locationSharing === false
+                          ? "text-destructive"
+                          : "text-muted-foreground"
+                      }`}
+                    >
+                      {locationSharing === null ? "—" : locationSharing ? "Enabled" : "Disabled"}
+                    </span>
+                  </div>
+                  {locationShareReason ? (
+                    <p className="text-sm text-muted-foreground">
+                      Last shared for {locationShareReason === "sos" ? "an SOS alert" : "an escalation"}
+                      {locationSharedAt ? ` (${formatWhen(locationSharedAt)})` : ""}.
+                    </p>
+                  ) : (
+                    <p className="text-sm text-muted-foreground">
+                      {locationSharing === true
+                        ? "Your location stays hidden until an SOS alert or escalation occurs."
+                        : "Turn this on to optionally send your location during SOS alerts or escalations."}
+                    </p>
+                  )}
+                  {locationSharing ? (
+                    <div className="flex flex-col gap-2 sm:flex-row">
+                      <Button onClick={disableLocationSharing} disabled={locationMutationPending}>
+                        {locationMutationPending ? "Disabling…" : "Disable & Clear"}
+                      </Button>
+                      <Button
+                        variant="outline"
+                        onClick={handleClearSharedLocation}
+                        disabled={clearingLocation || locationMutationPending || !locationShareReason}
+                      >
+                        {clearingLocation ? "Clearing…" : "Clear last share"}
+                      </Button>
+                    </div>
+                  ) : (
+                    <Button onClick={enableLocationSharing} disabled={locationMutationPending}>
+                      {locationMutationPending ? "Enabling…" : "Enable location sharing"}
+                    </Button>
+                  )}
+                  {sharingLocation && (
+                    <p className="text-xs text-muted-foreground">Sharing your current location…</p>
+                  )}
+                </section>
               </CardContent>
             </Card>
 


### PR DESCRIPTION
## Summary
- combine the dashboard controls for emergency callback, check-in interval, and location sharing into a single "Your Settings" card
- leave the emergency contacts module as the dedicated card while removing the redundant interval and location cards
- add visual separators to clarify sections within the consolidated card

## Testing
- npm run lint *(fails: `next` command not available in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ea8f58b060832396fec44a006f8614