### PR TITLE
Refine dashboard layout

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -44,6 +44,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import { Separator } from "@/components/ui/separator";
 import { useToast } from "@/hooks/use-toast";
 
 // icons
@@ -1012,11 +1013,11 @@ export default function DashboardPage() {
       <Header />
       <main className="flex-grow container mx-auto px-4 py-8">
         <h1 className="text-3xl md:text-4xl font-headline font-bold mb-6">Your Dashboard</h1>
-        <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
-          {/* Left column */}
-          <div className="lg:col-span-2 grid grid-cols-1 md:grid-cols-2 gap-6">
+        <div className="grid grid-cols-1 gap-6 lg:grid-cols-2 xl:grid-cols-12">
+          {/* Primary column */}
+          <div className="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:col-span-1 xl:col-span-7">
             {/* SOS */}
-            <Card className="text-center bg-destructive/10 border-destructive shadow-lg hover:shadow-xl transition-shadow">
+            <Card className="text-center bg-destructive/10 border-destructive shadow-lg hover:shadow-xl transition-shadow sm:col-span-2">
               <CardHeader>
                 <CardTitle className="text-3xl font-headline text-destructive">Emergency SOS</CardTitle>
                 <CardDescription className="text-destructive/80">
@@ -1096,32 +1097,6 @@ export default function DashboardPage() {
               </CardContent>
             </Card>
 
-            {/* Interval */}
-            <Card className="shadow-lg">
-              <CardHeader className="flex flex-row items-center justify-between">
-                <div>
-                  <CardTitle className="text-2xl font-headline">Set Interval</CardTitle>
-                  <CardDescription>Choose your check-in frequency.</CardDescription>
-                </div>
-                <Clock className="h-8 w-8 text-muted-foreground" />
-              </CardHeader>
-              <CardContent>
-                <Select onValueChange={handleIntervalChange} value={selectedHours}>
-                  <SelectTrigger className="w-full text-lg">
-                    <SelectValue placeholder="Select interval" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {HOURS_OPTIONS.map((h) => (
-                      <SelectItem key={h} value={String(h)}>{`Every ${h} hours`}</SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
-                <p className="mt-2 text-sm text-muted-foreground">
-                  Current interval: {Math.floor(intervalMinutes / 60)}h {intervalMinutes % 60}m
-                </p>
-              </CardContent>
-            </Card>
-
             {/* Status */}
             <Card className="shadow-lg">
               <CardHeader className="flex flex-row items-center justify-between">
@@ -1181,116 +1156,7 @@ export default function DashboardPage() {
               </CardContent>
             </Card>
 
-            {/* Location Sharing */}
-            <Card className="shadow-lg">
-              <CardHeader>
-                <CardTitle className="text-2xl font-headline">Location Sharing</CardTitle>
-                <CardDescription>Share your location only when an alert is active.</CardDescription>
-              </CardHeader>
-              <CardContent className="space-y-4 text-left">
-                <p className="text-sm text-muted-foreground">
-                  We only send your location when you press SOS or when an escalation begins.
-                </p>
-                <div className="flex items-center justify-between text-lg">
-                  <span className="font-semibold">Consent</span>
-                  <span
-                    className={`font-bold ${
-                      locationSharing === true
-                        ? "text-green-600"
-                        : locationSharing === false
-                        ? "text-destructive"
-                        : "text-muted-foreground"
-                    }`}
-                  >
-                    {locationSharing === null ? "—" : locationSharing ? "Enabled" : "Disabled"}
-                  </span>
-                </div>
-                {locationShareReason ? (
-                  <p className="text-sm text-muted-foreground">
-                    Last shared for {locationShareReason === "sos" ? "an SOS alert" : "an escalation"}
-                    {locationSharedAt ? ` (${formatWhen(locationSharedAt)})` : ""}.
-                  </p>
-                ) : (
-                  <p className="text-sm text-muted-foreground">
-                    {locationSharing === true
-                      ? "Your location stays hidden until an SOS alert or escalation occurs."
-                      : "Turn this on to optionally send your location during SOS alerts or escalations."}
-                  </p>
-                )}
-                {locationSharing ? (
-                  <div className="flex flex-col gap-2 sm:flex-row">
-                    <Button onClick={disableLocationSharing} disabled={locationMutationPending}>
-                      {locationMutationPending ? "Disabling…" : "Disable & Clear"}
-                    </Button>
-                    <Button
-                      variant="outline"
-                      onClick={handleClearSharedLocation}
-                      disabled={clearingLocation || locationMutationPending || !locationShareReason}
-                    >
-                      {clearingLocation ? "Clearing…" : "Clear last share"}
-                    </Button>
-                  </div>
-                ) : (
-                  <Button onClick={enableLocationSharing} disabled={locationMutationPending}>
-                    {locationMutationPending ? "Enabling…" : "Enable location sharing"}
-                  </Button>
-                )}
-                {sharingLocation && (
-                  <p className="text-xs text-muted-foreground">Sharing your current location…</p>
-                )}
-              </CardContent>
-            </Card>
-
-            {/* Emergency Contacts */}
-            <div className="md:col-span-2">
-              <EmergencyContacts />
-            </div>
-          </div>
-
-          {/* Right column */}
-          <div className="lg:col-span-1 space-y-6">
-            <Card className="p-4 shadow-lg">
-              <CardHeader>
-                <CardTitle className="text-2xl font-headline">Emergency Callback</CardTitle>
-                <CardDescription>
-                  Emergency contacts tap “Call” to reach you at this number.
-                </CardDescription>
-              </CardHeader>
-              <CardContent className="space-y-4">
-                <div className="space-y-2">
-                  <Label htmlFor="main-user-phone">Mobile phone</Label>
-                  <Input
-                    id="main-user-phone"
-                    placeholder="+15551234567"
-                    value={phoneDraft}
-                    onChange={(event) => setPhoneDraft(event.target.value)}
-                    disabled={phoneSaving}
-                    inputMode="tel"
-                  />
-                  <p className="text-xs text-muted-foreground">
-                    Include country code. We’ll auto-format for emergency contacts.
-                  </p>
-                </div>
-                <div className="flex flex-col gap-2 sm:flex-row">
-                  <Button
-                    onClick={handlePhoneSave}
-                    disabled={phoneSaving || !phoneDirty}
-                    className="sm:flex-1"
-                  >
-                    {phoneSaving ? "Saving…" : "Save number"}
-                  </Button>
-                  <Button
-                    variant="outline"
-                    onClick={handlePhoneReset}
-                    disabled={phoneSaving || !phoneDirty}
-                  >
-                    Cancel
-                  </Button>
-                </div>
-              </CardContent>
-            </Card>
-
-            <Card className="p-4 shadow-lg">
+            <Card className="p-4 shadow-lg sm:col-span-2">
               <CardHeader>
                 <CardTitle className="text-2xl font-headline">Voice Check-in</CardTitle>
                 <CardDescription>Say “I'm OK” to check in.</CardDescription>
@@ -1299,6 +1165,148 @@ export default function DashboardPage() {
                 <VoiceCheckIn onCheckIn={handleCheckIn} />
               </CardContent>
             </Card>
+          </div>
+
+          {/* Secondary column */}
+          <div className="space-y-6 lg:col-span-1 xl:col-span-5">
+            <Card className="p-4 shadow-lg">
+              <CardHeader className="pb-4">
+                <CardTitle className="text-2xl font-headline">Your Settings</CardTitle>
+                <CardDescription>
+                  Manage how you stay connected with your emergency contacts.
+                </CardDescription>
+              </CardHeader>
+              <CardContent className="space-y-6">
+                <section className="space-y-3">
+                  <div>
+                    <h3 className="text-lg font-semibold">Emergency Callback</h3>
+                    <p className="text-sm text-muted-foreground">
+                      Emergency contacts tap “Call” to reach you at this number.
+                    </p>
+                  </div>
+                  <div className="space-y-2">
+                    <Label htmlFor="main-user-phone">Mobile phone</Label>
+                    <Input
+                      id="main-user-phone"
+                      placeholder="+15551234567"
+                      value={phoneDraft}
+                      onChange={(event) => setPhoneDraft(event.target.value)}
+                      disabled={phoneSaving}
+                      inputMode="tel"
+                    />
+                    <p className="text-xs text-muted-foreground">
+                      Include country code. We’ll auto-format for emergency contacts.
+                    </p>
+                  </div>
+                  <div className="flex flex-col gap-2 sm:flex-row">
+                    <Button
+                      onClick={handlePhoneSave}
+                      disabled={phoneSaving || !phoneDirty}
+                      className="sm:flex-1"
+                    >
+                      {phoneSaving ? "Saving…" : "Save number"}
+                    </Button>
+                    <Button
+                      variant="outline"
+                      onClick={handlePhoneReset}
+                      disabled={phoneSaving || !phoneDirty}
+                    >
+                      Cancel
+                    </Button>
+                  </div>
+                </section>
+
+                <Separator />
+
+                <section className="space-y-3">
+                  <div className="flex items-center justify-between gap-4">
+                    <div>
+                      <h3 className="text-lg font-semibold">Set Interval</h3>
+                      <p className="text-sm text-muted-foreground">
+                        Choose your check-in frequency.
+                      </p>
+                    </div>
+                    <Clock className="h-6 w-6 text-muted-foreground" />
+                  </div>
+                  <Select onValueChange={handleIntervalChange} value={selectedHours}>
+                    <SelectTrigger className="w-full text-lg">
+                      <SelectValue placeholder="Select interval" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {HOURS_OPTIONS.map((h) => (
+                        <SelectItem key={h} value={String(h)}>{`Every ${h} hours`}</SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                  <p className="text-sm text-muted-foreground">
+                    Current interval: {Math.floor(intervalMinutes / 60)}h {intervalMinutes % 60}m
+                  </p>
+                </section>
+
+                <Separator />
+
+                <section className="space-y-3">
+                  <div>
+                    <h3 className="text-lg font-semibold">Location Sharing</h3>
+                    <p className="text-sm text-muted-foreground">
+                      Share your location only when an alert is active.
+                    </p>
+                  </div>
+                  <p className="text-sm text-muted-foreground">
+                    We only send your location when you press SOS or when an escalation begins.
+                  </p>
+                  <div className="flex items-center justify-between text-lg">
+                    <span className="font-semibold">Consent</span>
+                    <span
+                      className={`font-bold ${
+                        locationSharing === true
+                          ? "text-green-600"
+                          : locationSharing === false
+                          ? "text-destructive"
+                          : "text-muted-foreground"
+                      }`}
+                    >
+                      {locationSharing === null ? "—" : locationSharing ? "Enabled" : "Disabled"}
+                    </span>
+                  </div>
+                  {locationShareReason ? (
+                    <p className="text-sm text-muted-foreground">
+                      Last shared for {locationShareReason === "sos" ? "an SOS alert" : "an escalation"}
+                      {locationSharedAt ? ` (${formatWhen(locationSharedAt)})` : ""}.
+                    </p>
+                  ) : (
+                    <p className="text-sm text-muted-foreground">
+                      {locationSharing === true
+                        ? "Your location stays hidden until an SOS alert or escalation occurs."
+                        : "Turn this on to optionally send your location during SOS alerts or escalations."}
+                    </p>
+                  )}
+                  {locationSharing ? (
+                    <div className="flex flex-col gap-2 sm:flex-row">
+                      <Button onClick={disableLocationSharing} disabled={locationMutationPending}>
+                        {locationMutationPending ? "Disabling…" : "Disable & Clear"}
+                      </Button>
+                      <Button
+                        variant="outline"
+                        onClick={handleClearSharedLocation}
+                        disabled={clearingLocation || locationMutationPending || !locationShareReason}
+                      >
+                        {clearingLocation ? "Clearing…" : "Clear last share"}
+                      </Button>
+                    </div>
+                  ) : (
+                    <Button onClick={enableLocationSharing} disabled={locationMutationPending}>
+                      {locationMutationPending ? "Enabling…" : "Enable location sharing"}
+                    </Button>
+                  )}
+                  {sharingLocation && (
+                    <p className="text-xs text-muted-foreground">Sharing your current location…</p>
+                  )}
+                </section>
+              </CardContent>
+            </Card>
+
+            <EmergencyContacts />
           </div>
         </div>
       </main>

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1018,9 +1018,9 @@ export default function DashboardPage() {
           <div className="grid grid-cols-1 gap-6 sm:grid-cols-2 auto-rows-[minmax(20rem,_1fr)] lg:col-span-1 xl:col-span-7">
             {/* SOS */}
             <Card className="flex h-full min-h-[20rem] flex-col text-center bg-destructive/10 border-destructive shadow-lg hover:shadow-xl transition-shadow">
-              <CardHeader>
-                <CardTitle className="text-3xl font-headline text-destructive">Emergency SOS</CardTitle>
-                <CardDescription className="text-destructive/80">
+              <CardHeader className="space-y-2">
+                <CardTitle className="text-3xl font-headline font-semibold text-destructive">Emergency SOS</CardTitle>
+                <CardDescription className="text-lg font-medium text-destructive/80">
                   Tap only in a real emergency. We will dial {emergencyService.dial} for
                   {" "}
                   {emergencyService.label}.
@@ -1069,7 +1069,7 @@ export default function DashboardPage() {
                   </div>
 
                   {/* Helper caption */}
-                  <p className="text-sm text-destructive/80">
+                  <p className="text-lg font-medium text-destructive/80">
                     {holding
                       ? ready
                         ? `Release to call ${emergencyService.dial}`
@@ -1082,8 +1082,8 @@ export default function DashboardPage() {
 
             {/* Manual Check-in */}
             <Card className="flex h-full min-h-[20rem] flex-col text-center shadow-lg hover:shadow-xl transition-shadow">
-              <CardHeader>
-                <CardTitle className="text-3xl font-headline">Manual Check-in</CardTitle>
+              <CardHeader className="space-y-2">
+                <CardTitle className="text-3xl font-headline font-semibold">Manual Check-in</CardTitle>
               </CardHeader>
               <CardContent className="flex flex-1 flex-col items-center justify-center gap-6">
                 <Button
@@ -1100,9 +1100,9 @@ export default function DashboardPage() {
             </Card>
 
             <Card className="flex h-full min-h-[20rem] flex-col p-4 shadow-lg">
-              <CardHeader>
-                <CardTitle className="text-2xl font-headline">Voice Check-in</CardTitle>
-                <CardDescription>Say “I'm OK” to check in.</CardDescription>
+              <CardHeader className="space-y-2 text-center">
+                <CardTitle className="text-3xl font-headline font-semibold">Voice Check-in</CardTitle>
+                <CardDescription className="text-lg text-muted-foreground">Say “I'm OK” to check in.</CardDescription>
               </CardHeader>
               <CardContent className="flex flex-1 flex-col items-center justify-center text-center">
                 <VoiceCheckIn onCheckIn={handleCheckIn} />
@@ -1113,8 +1113,8 @@ export default function DashboardPage() {
             <Card className="flex h-full min-h-[20rem] flex-col shadow-lg">
               <CardHeader className="flex flex-row items-center justify-between">
                 <div>
-                  <CardTitle className="text-2xl font-headline">Status</CardTitle>
-                  <CardDescription>Your latest activity.</CardDescription>
+                  <CardTitle className="text-3xl font-headline font-semibold">Status</CardTitle>
+                  <CardDescription className="text-lg text-muted-foreground">Your latest activity.</CardDescription>
                 </div>
                 <Timer className="h-8 w-8 text-muted-foreground" />
               </CardHeader>

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1097,6 +1097,16 @@ export default function DashboardPage() {
               </CardContent>
             </Card>
 
+            <Card className="p-4 shadow-lg sm:col-span-2">
+              <CardHeader>
+                <CardTitle className="text-2xl font-headline">Voice Check-in</CardTitle>
+                <CardDescription>Say “I'm OK” to check in.</CardDescription>
+              </CardHeader>
+              <CardContent>
+                <VoiceCheckIn onCheckIn={handleCheckIn} />
+              </CardContent>
+            </Card>
+
             {/* Status */}
             <Card className="shadow-lg">
               <CardHeader className="flex flex-row items-center justify-between">
@@ -1155,20 +1165,12 @@ export default function DashboardPage() {
                 </p>
               </CardContent>
             </Card>
-
-            <Card className="p-4 shadow-lg sm:col-span-2">
-              <CardHeader>
-                <CardTitle className="text-2xl font-headline">Voice Check-in</CardTitle>
-                <CardDescription>Say “I'm OK” to check in.</CardDescription>
-              </CardHeader>
-              <CardContent>
-                <VoiceCheckIn onCheckIn={handleCheckIn} />
-              </CardContent>
-            </Card>
           </div>
 
           {/* Secondary column */}
           <div className="space-y-6 lg:col-span-1 xl:col-span-5">
+            <EmergencyContacts />
+
             <Card className="p-4 shadow-lg">
               <CardHeader className="pb-4">
                 <CardTitle className="text-2xl font-headline">Your Settings</CardTitle>
@@ -1305,8 +1307,6 @@ export default function DashboardPage() {
                 </section>
               </CardContent>
             </Card>
-
-            <EmergencyContacts />
           </div>
         </div>
       </main>

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1112,14 +1112,16 @@ export default function DashboardPage() {
               </CardContent>
             </Card>
 
-            <Card className={`${PRIMARY_CARD_BASE_CLASSES} p-4 text-center`}>
+            <Card
+              className={`${PRIMARY_CARD_BASE_CLASSES} border-2 border-primary/30 text-center`}
+            >
               <CardHeader className={PRIMARY_CARD_HEADER_CLASSES}>
                 <CardTitle className={PRIMARY_CARD_TITLE_CLASSES}>Voice Check-in</CardTitle>
                 <CardDescription className={PRIMARY_CARD_DESCRIPTION_CLASSES}>
-                  Say “I'm OK” to check in.
+                  Check in hands-free with a quick voice command.
                 </CardDescription>
               </CardHeader>
-              <CardContent className="flex flex-1 flex-col items-center justify-center text-center">
+              <CardContent className="flex flex-1 flex-col items-center justify-center gap-6 text-center">
                 <VoiceCheckIn onCheckIn={handleCheckIn} />
               </CardContent>
             </Card>

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1015,7 +1015,7 @@ export default function DashboardPage() {
         <h1 className="text-3xl md:text-4xl font-headline font-bold mb-6">Your Dashboard</h1>
         <div className="grid grid-cols-1 gap-6 lg:grid-cols-2 xl:grid-cols-12">
           {/* Primary column */}
-          <div className="grid grid-cols-1 gap-6 sm:grid-cols-2 auto-rows-[minmax(0,1fr)] lg:col-span-1 xl:col-span-7">
+          <div className="grid grid-cols-1 gap-6 sm:grid-cols-2 auto-rows-[minmax(0,18rem)] lg:col-span-1 xl:col-span-7">
             {/* SOS */}
             <Card className="flex h-full flex-col text-center bg-destructive/10 border-destructive shadow-lg hover:shadow-xl transition-shadow">
               <CardHeader>
@@ -1168,7 +1168,7 @@ export default function DashboardPage() {
           </div>
 
           {/* Secondary column */}
-          <div className="space-y-6 lg:col-span-1 xl:col-span-5">
+          <div className="space-y-6 lg:col-span-1 xl:col-span-4 xl:col-start-9">
             <EmergencyContacts />
 
             <Card className="p-4 shadow-lg">

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -94,6 +94,12 @@ const GEO_PERMISSION_DENIED = 1;
 const GEO_POSITION_UNAVAILABLE = 2;
 const GEO_TIMEOUT = 3;
 
+const PRIMARY_CARD_BASE_CLASSES =
+  "flex min-h-[20rem] flex-col shadow-lg transition-shadow hover:shadow-xl";
+const PRIMARY_CARD_HEADER_CLASSES = "space-y-3 text-center";
+const PRIMARY_CARD_TITLE_CLASSES = "text-3xl font-headline font-semibold";
+const PRIMARY_CARD_DESCRIPTION_CLASSES = "text-lg text-muted-foreground";
+
 function describeGeoError(error: unknown) {
   const defaultMessage =
     "We couldn't access your current location. Please enable location services and try again.";
@@ -1017,16 +1023,20 @@ export default function DashboardPage() {
           {/* Primary column */}
           <div className="grid grid-cols-1 gap-6 sm:grid-cols-2 auto-rows-[minmax(20rem,_1fr)] lg:col-span-1 xl:col-span-7">
             {/* SOS */}
-            <Card className="flex h-full min-h-[20rem] flex-col text-center bg-destructive/10 border-destructive shadow-lg hover:shadow-xl transition-shadow">
-              <CardHeader className="space-y-2">
-                <CardTitle className="text-3xl font-headline font-semibold text-destructive">Emergency SOS</CardTitle>
-                <CardDescription className="text-lg font-medium text-destructive/80">
+            <Card
+              className={`${PRIMARY_CARD_BASE_CLASSES} border border-destructive bg-destructive/10 text-center`}
+            >
+              <CardHeader className={PRIMARY_CARD_HEADER_CLASSES}>
+                <CardTitle className={`${PRIMARY_CARD_TITLE_CLASSES} text-destructive`}>
+                  Emergency SOS
+                </CardTitle>
+                <CardDescription className={`${PRIMARY_CARD_DESCRIPTION_CLASSES} font-medium text-destructive/80`}>
                   Tap only in a real emergency. We will dial {emergencyService.dial} for
                   {" "}
                   {emergencyService.label}.
                 </CardDescription>
               </CardHeader>
-              <CardContent className="flex flex-1 flex-col justify-center">
+              <CardContent className="flex flex-1 flex-col items-center justify-center gap-4">
                 <div className="flex flex-col items-center gap-3" aria-live="polite">
                   {/* Radial progress ring around the button */}
                   <div
@@ -1081,11 +1091,14 @@ export default function DashboardPage() {
             </Card>
 
             {/* Manual Check-in */}
-            <Card className="flex h-full min-h-[20rem] flex-col text-center shadow-lg hover:shadow-xl transition-shadow">
-              <CardHeader className="space-y-2">
-                <CardTitle className="text-3xl font-headline font-semibold">Manual Check-in</CardTitle>
+            <Card className={`${PRIMARY_CARD_BASE_CLASSES} text-center`}>
+              <CardHeader className={PRIMARY_CARD_HEADER_CLASSES}>
+                <CardTitle className={PRIMARY_CARD_TITLE_CLASSES}>Manual Check-in</CardTitle>
+                <CardDescription className={PRIMARY_CARD_DESCRIPTION_CLASSES}>
+                  Check in manually whenever you need.
+                </CardDescription>
               </CardHeader>
-              <CardContent className="flex flex-1 flex-col items-center justify-center gap-6">
+              <CardContent className="flex flex-1 flex-col items-center justify-center gap-6 text-center">
                 <Button
                   onClick={() => handleCheckIn()}
                   size="lg"
@@ -1099,10 +1112,12 @@ export default function DashboardPage() {
               </CardContent>
             </Card>
 
-            <Card className="flex h-full min-h-[20rem] flex-col p-4 shadow-lg">
-              <CardHeader className="space-y-2 text-center">
-                <CardTitle className="text-3xl font-headline font-semibold">Voice Check-in</CardTitle>
-                <CardDescription className="text-lg text-muted-foreground">Say “I'm OK” to check in.</CardDescription>
+            <Card className={`${PRIMARY_CARD_BASE_CLASSES} p-4 text-center`}>
+              <CardHeader className={PRIMARY_CARD_HEADER_CLASSES}>
+                <CardTitle className={PRIMARY_CARD_TITLE_CLASSES}>Voice Check-in</CardTitle>
+                <CardDescription className={PRIMARY_CARD_DESCRIPTION_CLASSES}>
+                  Say “I'm OK” to check in.
+                </CardDescription>
               </CardHeader>
               <CardContent className="flex flex-1 flex-col items-center justify-center text-center">
                 <VoiceCheckIn onCheckIn={handleCheckIn} />
@@ -1110,15 +1125,15 @@ export default function DashboardPage() {
             </Card>
 
             {/* Status */}
-            <Card className="flex h-full min-h-[20rem] flex-col shadow-lg">
-              <CardHeader className="flex flex-row items-center justify-between">
-                <div>
-                  <CardTitle className="text-3xl font-headline font-semibold">Status</CardTitle>
-                  <CardDescription className="text-lg text-muted-foreground">Your latest activity.</CardDescription>
-                </div>
-                <Timer className="h-8 w-8 text-muted-foreground" />
+            <Card className={PRIMARY_CARD_BASE_CLASSES}>
+              <CardHeader className={`${PRIMARY_CARD_HEADER_CLASSES} items-center`}>
+                <Timer className="mx-auto h-10 w-10 text-muted-foreground" aria-hidden />
+                <CardTitle className={PRIMARY_CARD_TITLE_CLASSES}>Status</CardTitle>
+                <CardDescription className={PRIMARY_CARD_DESCRIPTION_CLASSES}>
+                  Your latest activity.
+                </CardDescription>
               </CardHeader>
-              <CardContent className="flex flex-1 flex-col justify-center gap-3 text-lg">
+              <CardContent className="flex flex-1 flex-col justify-center gap-3 text-lg text-center">
                 <p>
                   Last Check-in:{" "}
                   <span className="font-bold text-primary">{formatWhen(lastCheckIn)}</span>

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1037,7 +1037,7 @@ export default function DashboardPage() {
                 </CardDescription>
               </CardHeader>
               <CardContent className="flex flex-1 flex-col items-center justify-center gap-4">
-                <div className="flex flex-col items-center gap-3" aria-live="polite">
+                <div className="flex flex-col items-center gap-4" aria-live="polite">
                   {/* Radial progress ring around the button */}
                   <div
                     className="relative h-40 w-40 grid place-items-center"
@@ -1079,7 +1079,7 @@ export default function DashboardPage() {
                   </div>
 
                   {/* Helper caption */}
-                  <p className="text-lg font-medium text-destructive/80">
+                  <p className="text-3xl font-semibold text-destructive/80">
                     {holding
                       ? ready
                         ? `Release to call ${emergencyService.dial}`
@@ -1099,14 +1099,16 @@ export default function DashboardPage() {
                 </CardDescription>
               </CardHeader>
               <CardContent className="flex flex-1 flex-col items-center justify-center gap-6 text-center">
-                <Button
-                  onClick={() => handleCheckIn()}
-                  size="lg"
-                  className="h-32 w-32 rounded-full text-2xl shadow-lg bg-green-500 hover:bg-green-600"
-                >
-                  <CheckCircle2 className="h-16 w-16" />
-                </Button>
-                <p className="text-2xl font-semibold text-muted-foreground">
+                <div className="relative h-40 w-40 grid place-items-center">
+                  <Button
+                    onClick={() => handleCheckIn()}
+                    size="lg"
+                    className="h-28 w-28 rounded-full text-2xl shadow-lg bg-green-500 hover:bg-green-600"
+                  >
+                    <CheckCircle2 className="h-16 w-16" />
+                  </Button>
+                </div>
+                <p className="text-3xl font-semibold text-muted-foreground">
                   Press the button to check in.
                 </p>
               </CardContent>

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1015,9 +1015,9 @@ export default function DashboardPage() {
         <h1 className="text-3xl md:text-4xl font-headline font-bold mb-6">Your Dashboard</h1>
         <div className="grid grid-cols-1 gap-6 lg:grid-cols-2 xl:grid-cols-12">
           {/* Primary column */}
-          <div className="grid grid-cols-1 gap-6 sm:grid-cols-2 auto-rows-[minmax(0,18rem)] lg:col-span-1 xl:col-span-7">
+          <div className="grid grid-cols-1 gap-6 sm:grid-cols-2 auto-rows-[minmax(20rem,_1fr)] lg:col-span-1 xl:col-span-7">
             {/* SOS */}
-            <Card className="flex h-full flex-col text-center bg-destructive/10 border-destructive shadow-lg hover:shadow-xl transition-shadow">
+            <Card className="flex h-full min-h-[20rem] flex-col text-center bg-destructive/10 border-destructive shadow-lg hover:shadow-xl transition-shadow">
               <CardHeader>
                 <CardTitle className="text-3xl font-headline text-destructive">Emergency SOS</CardTitle>
                 <CardDescription className="text-destructive/80">
@@ -1081,7 +1081,7 @@ export default function DashboardPage() {
             </Card>
 
             {/* Manual Check-in */}
-            <Card className="flex h-full flex-col text-center shadow-lg hover:shadow-xl transition-shadow">
+            <Card className="flex h-full min-h-[20rem] flex-col text-center shadow-lg hover:shadow-xl transition-shadow">
               <CardHeader>
                 <CardTitle className="text-3xl font-headline">Manual Check-in</CardTitle>
               </CardHeader>
@@ -1099,18 +1099,18 @@ export default function DashboardPage() {
               </CardContent>
             </Card>
 
-            <Card className="flex h-full flex-col p-4 shadow-lg">
+            <Card className="flex h-full min-h-[20rem] flex-col p-4 shadow-lg">
               <CardHeader>
                 <CardTitle className="text-2xl font-headline">Voice Check-in</CardTitle>
                 <CardDescription>Say “I'm OK” to check in.</CardDescription>
               </CardHeader>
-              <CardContent className="flex flex-1 flex-col justify-center">
+              <CardContent className="flex flex-1 flex-col items-center justify-center text-center">
                 <VoiceCheckIn onCheckIn={handleCheckIn} />
               </CardContent>
             </Card>
 
             {/* Status */}
-            <Card className="flex h-full flex-col shadow-lg">
+            <Card className="flex h-full min-h-[20rem] flex-col shadow-lg">
               <CardHeader className="flex flex-row items-center justify-between">
                 <div>
                   <CardTitle className="text-2xl font-headline">Status</CardTitle>
@@ -1118,16 +1118,16 @@ export default function DashboardPage() {
                 </div>
                 <Timer className="h-8 w-8 text-muted-foreground" />
               </CardHeader>
-              <CardContent className="flex-1 space-y-2">
-                <p className="text-lg">
+              <CardContent className="flex flex-1 flex-col justify-center gap-3 text-lg">
+                <p>
                   Last Check-in:{" "}
                   <span className="font-bold text-primary">{formatWhen(lastCheckIn)}</span>
                 </p>
-                <p className="text-lg">
+                <p>
                   Next scheduled check-in:{" "}
                   <span className="font-bold text-primary">{formatWhen(nextCheckIn)}</span>
                 </p>
-                <p className="text-lg">
+                <p>
                   Countdown:{" "}
                   <span
                     className={
@@ -1137,7 +1137,7 @@ export default function DashboardPage() {
                     {timeLeft || "—"}
                   </span>
                 </p>
-                <p className="text-lg">
+                <p>
                   Status:{" "}
                   <span
                     className={

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1084,9 +1084,8 @@ export default function DashboardPage() {
             <Card className="flex h-full flex-col text-center shadow-lg hover:shadow-xl transition-shadow">
               <CardHeader>
                 <CardTitle className="text-3xl font-headline">Manual Check-in</CardTitle>
-                <CardDescription>Let your emergency contacts know you're safe.</CardDescription>
               </CardHeader>
-              <CardContent className="flex flex-1 items-center justify-center">
+              <CardContent className="flex flex-1 flex-col items-center justify-center gap-6">
                 <Button
                   onClick={() => handleCheckIn()}
                   size="lg"
@@ -1094,6 +1093,9 @@ export default function DashboardPage() {
                 >
                   <CheckCircle2 className="h-16 w-16" />
                 </Button>
+                <p className="text-2xl font-semibold text-muted-foreground">
+                  Press the button to check in.
+                </p>
               </CardContent>
             </Card>
 

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1015,9 +1015,9 @@ export default function DashboardPage() {
         <h1 className="text-3xl md:text-4xl font-headline font-bold mb-6">Your Dashboard</h1>
         <div className="grid grid-cols-1 gap-6 lg:grid-cols-2 xl:grid-cols-12">
           {/* Primary column */}
-          <div className="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:col-span-1 xl:col-span-7">
+          <div className="grid grid-cols-1 gap-6 sm:grid-cols-2 auto-rows-[minmax(0,1fr)] lg:col-span-1 xl:col-span-7">
             {/* SOS */}
-            <Card className="text-center bg-destructive/10 border-destructive shadow-lg hover:shadow-xl transition-shadow sm:col-span-2">
+            <Card className="flex h-full flex-col text-center bg-destructive/10 border-destructive shadow-lg hover:shadow-xl transition-shadow">
               <CardHeader>
                 <CardTitle className="text-3xl font-headline text-destructive">Emergency SOS</CardTitle>
                 <CardDescription className="text-destructive/80">
@@ -1026,7 +1026,7 @@ export default function DashboardPage() {
                   {emergencyService.label}.
                 </CardDescription>
               </CardHeader>
-              <CardContent>
+              <CardContent className="flex flex-1 flex-col justify-center">
                 <div className="flex flex-col items-center gap-3" aria-live="polite">
                   {/* Radial progress ring around the button */}
                   <div
@@ -1081,12 +1081,12 @@ export default function DashboardPage() {
             </Card>
 
             {/* Manual Check-in */}
-            <Card className="text-center shadow-lg hover:shadow-xl transition-shadow">
+            <Card className="flex h-full flex-col text-center shadow-lg hover:shadow-xl transition-shadow">
               <CardHeader>
                 <CardTitle className="text-3xl font-headline">Manual Check-in</CardTitle>
                 <CardDescription>Let your emergency contacts know you're safe.</CardDescription>
               </CardHeader>
-              <CardContent>
+              <CardContent className="flex flex-1 items-center justify-center">
                 <Button
                   onClick={() => handleCheckIn()}
                   size="lg"
@@ -1097,18 +1097,18 @@ export default function DashboardPage() {
               </CardContent>
             </Card>
 
-            <Card className="p-4 shadow-lg sm:col-span-2">
+            <Card className="flex h-full flex-col p-4 shadow-lg">
               <CardHeader>
                 <CardTitle className="text-2xl font-headline">Voice Check-in</CardTitle>
                 <CardDescription>Say “I'm OK” to check in.</CardDescription>
               </CardHeader>
-              <CardContent>
+              <CardContent className="flex flex-1 flex-col justify-center">
                 <VoiceCheckIn onCheckIn={handleCheckIn} />
               </CardContent>
             </Card>
 
             {/* Status */}
-            <Card className="shadow-lg">
+            <Card className="flex h-full flex-col shadow-lg">
               <CardHeader className="flex flex-row items-center justify-between">
                 <div>
                   <CardTitle className="text-2xl font-headline">Status</CardTitle>
@@ -1116,7 +1116,7 @@ export default function DashboardPage() {
                 </div>
                 <Timer className="h-8 w-8 text-muted-foreground" />
               </CardHeader>
-              <CardContent className="space-y-2">
+              <CardContent className="flex-1 space-y-2">
                 <p className="text-lg">
                   Last Check-in:{" "}
                   <span className="font-bold text-primary">{formatWhen(lastCheckIn)}</span>

--- a/src/components/voice-check-in.tsx
+++ b/src/components/voice-check-in.tsx
@@ -4,13 +4,6 @@
 import { useState, useEffect, useRef } from "react";
 import { Mic, MicOff, Loader, ShieldAlert, ShieldCheck } from "lucide-react";
 import { Button } from "@/components/ui/button";
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-} from "@/components/ui/card";
 import type { AssessVoiceCheckInOutput } from "@/ai/flows/voice-check-in-assessment";
 import { useToast } from "@/hooks/use-toast";
 
@@ -229,55 +222,48 @@ export function VoiceCheckIn({ onCheckIn }: VoiceCheckInProps) {
   };
 
   return (
-    <Card className="text-center flex flex-col justify-between h-full">
-      <CardHeader>
-        <CardTitle className="text-3xl font-headline">Voice Check-in</CardTitle>
-        <CardDescription>Press the button and say “I’m OK”.</CardDescription>
-      </CardHeader>
+    <div className="flex h-full w-full flex-col items-center justify-center gap-6 text-center">
+      {/* Visual status circle */}
+      <div className="flex h-32 w-32 items-center justify-center rounded-full bg-secondary shadow-inner">
+        {getStatusIcon()}
+      </div>
 
-      <CardContent className="flex flex-col items-center justify-center space-y-4 flex-grow">
-        {/* Visual status circle */}
-        <div className="w-24 h-24 rounded-full flex items-center justify-center bg-secondary mb-4">
-          {getStatusIcon()}
-        </div>
+      {/* ARIA live region so screen readers announce changes */}
+      <p className="text-2xl font-semibold text-muted-foreground" aria-live="polite">
+        {getStatusText()}
+      </p>
 
-        {/* ARIA live region so screen readers announce changes */}
-        <p className="font-semibold text-lg" aria-live="polite">
-          {getStatusText()}
-        </p>
+      {/* Show transcript once we have one */}
+      {transcript && <p className="text-base text-muted-foreground">You said: “{transcript}”</p>}
 
-        {/* Show transcript once we have one */}
-        {transcript && <p className="text-muted-foreground">You said: “{transcript}”</p>}
-
-        {/* AI explanation (green for OK, red for anomaly) */}
-        {assessment?.explanation && (
-          <p
-            className={`text-sm p-2 rounded-md ${
-              assessment.anomalyDetected ? "bg-destructive/10" : "bg-green-500/10"
-            }`}
-          >
-            <strong>AI Analysis:</strong> {assessment.explanation}
-          </p>
-        )}
-
-        {/* Start/Stop button */}
-        <Button
-          size="lg"
-          onClick={handleToggleListening}
-          disabled={isProcessing || !supported}
-          className="w-48 py-6 text-lg"
+      {/* AI explanation (green for OK, red for anomaly) */}
+      {assessment?.explanation && (
+        <p
+          className={`rounded-md p-3 text-base ${
+            assessment.anomalyDetected ? "bg-destructive/10" : "bg-green-500/10"
+          }`}
         >
-          {isListening ? <MicOff className="mr-2 h-6 w-6" /> : <Mic className="mr-2 h-6 w-6" />}
-          {isListening ? "Stop" : "Start"}
-        </Button>
+          <strong>AI Analysis:</strong> {assessment.explanation}
+        </p>
+      )}
 
-        {/* Tiny hint when unsupported */}
-        {!supported && (
-          <p className="text-xs text-muted-foreground">
-            Tip: Try the latest Chrome/Edge/Safari over HTTPS.
-          </p>
-        )}
-      </CardContent>
-    </Card>
+      {/* Start/Stop button */}
+      <Button
+        size="lg"
+        onClick={handleToggleListening}
+        disabled={isProcessing || !supported}
+        className="w-48 py-6 text-lg font-semibold"
+      >
+        {isListening ? <MicOff className="mr-2 h-6 w-6" /> : <Mic className="mr-2 h-6 w-6" />}
+        {isListening ? "Stop" : "Start"}
+      </Button>
+
+      {/* Tiny hint when unsupported */}
+      {!supported && (
+        <p className="text-sm text-muted-foreground">
+          Tip: Try the latest Chrome/Edge/Safari over HTTPS.
+        </p>
+      )}
+    </div>
   );
 }


### PR DESCRIPTION
## Summary
- combine the dashboard controls for emergency callback, check-in interval, and location sharing into a single "Your Settings" card
- leave the emergency contacts module as the dedicated card while removing the redundant interval and location cards
- add visual separators to clarify sections within the consolidated card
- reorganize the dashboard grid so cards stay balanced across screen sizes and position the voice check-in card directly after the status card

## Testing
- npm run lint *(fails: `next` command not available in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ea8f58b060832396fec44a006f8614