### PR TITLE
Separate status overview card

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1146,14 +1146,14 @@ export default function DashboardPage() {
               </CardContent>
             </Card>
 
-            <Card className={`${PRIMARY_CARD_BASE_CLASSES} min-h-0 sm:col-span-2`}>
-              <CardHeader className="space-y-2 text-left">
+            <Card className={`${PRIMARY_CARD_BASE_CLASSES} aspect-square min-h-0 text-left`}>
+              <CardHeader className="space-y-2">
                 <CardTitle className="text-2xl font-headline">Status Overview</CardTitle>
                 <CardDescription className="text-base">
                   Keep tabs on your latest check-in and countdown.
                 </CardDescription>
               </CardHeader>
-              <CardContent>
+              <CardContent className="flex flex-1 flex-col justify-center">
                 <dl className="grid gap-4 text-base sm:grid-cols-2">
                   <div className="space-y-1">
                     <dt className="text-sm text-muted-foreground">Last check-in</dt>

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -86,6 +86,12 @@ interface UserDoc {
 type Status = "safe" | "missed" | "unknown";
 type LocationShareReason = "sos" | "escalation";
 
+type VoiceMessageTarget = {
+  name: string;
+  email?: string | null;
+  phone?: string | null;
+};
+
 // helper to compute minutes-since-epoch
 const toEpochMinutes = (ms: number) => Math.floor(ms / 60000);
 
@@ -206,15 +212,21 @@ export default function DashboardPage() {
     useState<EmergencyServiceCountryCode>(DEFAULT_EMERGENCY_SERVICE_COUNTRY);
   const [primaryEmergencyContactPhone, setPrimaryEmergencyContactPhone] =
     useState<string | null>(null);
+  const [primaryEmergencyContactEmail, setPrimaryEmergencyContactEmail] =
+    useState<string | null>(null);
   const [primaryEmergencyContactName, setPrimaryEmergencyContactName] =
     useState<string>("Emergency Contact 1");
   const [secondaryEmergencyContactPhone, setSecondaryEmergencyContactPhone] =
+    useState<string | null>(null);
+  const [secondaryEmergencyContactEmail, setSecondaryEmergencyContactEmail] =
     useState<string | null>(null);
   const [secondaryEmergencyContactName, setSecondaryEmergencyContactName] =
     useState<string>("Emergency Contact 2");
   const [savedPhone, setSavedPhone] = useState<string>("");
   const [phoneDraft, setPhoneDraft] = useState<string>("");
   const [phoneSaving, setPhoneSaving] = useState(false);
+  const [voiceMessageTarget, setVoiceMessageTarget] =
+    useState<VoiceMessageTarget | null>(null);
 
   // 👇 explicit main user UID
   const [mainUserUid, setMainUserUid] = useState<string | null>(null);
@@ -281,6 +293,13 @@ export default function DashboardPage() {
         setSavedPhone("");
         setPhoneDraft("");
         setPhoneSaving(false);
+        setPrimaryEmergencyContactName("Emergency Contact 1");
+        setPrimaryEmergencyContactPhone(null);
+        setPrimaryEmergencyContactEmail(null);
+        setSecondaryEmergencyContactName("Emergency Contact 2");
+        setSecondaryEmergencyContactPhone(null);
+        setSecondaryEmergencyContactEmail(null);
+        setVoiceMessageTarget(null);
         return;
       }
 
@@ -375,6 +394,11 @@ export default function DashboardPage() {
               ? sanitizePhone(contacts.contact1_phone)
               : "";
           setPrimaryEmergencyContactPhone(phone || null);
+          const email =
+            typeof contacts.contact1_email === "string"
+              ? contacts.contact1_email.trim()
+              : "";
+          setPrimaryEmergencyContactEmail(email || null);
 
           const secondFirst =
             typeof contacts.contact2_firstName === "string"
@@ -394,12 +418,19 @@ export default function DashboardPage() {
               ? sanitizePhone(contacts.contact2_phone)
               : "";
           setSecondaryEmergencyContactPhone(secondPhone || null);
+          const secondEmail =
+            typeof contacts.contact2_email === "string"
+              ? contacts.contact2_email.trim()
+              : "";
+          setSecondaryEmergencyContactEmail(secondEmail || null);
         } else {
           setEmergencyServiceCountry(DEFAULT_EMERGENCY_SERVICE_COUNTRY);
           setPrimaryEmergencyContactName("Emergency Contact 1");
           setPrimaryEmergencyContactPhone(null);
+          setPrimaryEmergencyContactEmail(null);
           setSecondaryEmergencyContactName("Emergency Contact 2");
           setSecondaryEmergencyContactPhone(null);
+          setSecondaryEmergencyContactEmail(null);
         }
 
         setUserDocLoaded(true);
@@ -921,6 +952,60 @@ export default function DashboardPage() {
     [clearSharedLocation, intervalMinutes, locationShareReason, toast]
   );
 
+  const handleVoiceCheckInComplete = useCallback(async () => {
+    await handleCheckIn({ showToast: false });
+    setVoiceMessageTarget(null);
+  }, [handleCheckIn]);
+
+  const handleVoiceMessageContact = useCallback(
+    (contact: "primary" | "secondary") => {
+      const isPrimary = contact === "primary";
+      const name = isPrimary
+        ? primaryEmergencyContactName
+        : secondaryEmergencyContactName;
+      const phone = isPrimary
+        ? primaryEmergencyContactPhone
+        : secondaryEmergencyContactPhone;
+      const email = isPrimary
+        ? primaryEmergencyContactEmail
+        : secondaryEmergencyContactEmail;
+
+      if (!phone && !email) {
+        toast({
+          title: "Add contact details",
+          description:
+            "Provide a phone number or email to send them a voice message.",
+          variant: "destructive",
+        });
+        return;
+      }
+
+      setVoiceMessageTarget({
+        name,
+        phone: phone || undefined,
+        email: email || undefined,
+      });
+
+      const voiceCard = document.getElementById("voice-update-card");
+      if (voiceCard) {
+        voiceCard.scrollIntoView({ behavior: "smooth", block: "center" });
+        const primaryButton = voiceCard.querySelector<HTMLButtonElement>(
+          'button[data-voice-action="start"]',
+        );
+        primaryButton?.focus({ preventScroll: true });
+      }
+    },
+    [
+      primaryEmergencyContactEmail,
+      primaryEmergencyContactName,
+      primaryEmergencyContactPhone,
+      secondaryEmergencyContactEmail,
+      secondaryEmergencyContactName,
+      secondaryEmergencyContactPhone,
+      toast,
+    ],
+  );
+
   useEffect(() => {
     if (autoCheckInTriggeredRef.current) return;
     if (!roleChecked || !mainUserUid || !userDocLoaded || !userRef.current) return;
@@ -1239,32 +1324,56 @@ export default function DashboardPage() {
                     <p className="text-sm text-muted-foreground">
                       {primaryEmergencyContactPhone || "Add a phone number to enable calling."}
                     </p>
-                    <Button
-                      onClick={() => handleDialEmergencyContact(primaryEmergencyContactPhone)}
-                      disabled={!primaryEmergencyContactPhone}
-                      className="mt-3 w-full"
-                    >
-                      Call
-                    </Button>
+                    <div className="mt-3 grid grid-cols-1 gap-2 sm:grid-cols-2">
+                      <Button
+                        onClick={() => handleDialEmergencyContact(primaryEmergencyContactPhone)}
+                        disabled={!primaryEmergencyContactPhone}
+                        className="w-full"
+                      >
+                        Call
+                      </Button>
+                      <Button
+                        type="button"
+                        variant="outline"
+                        onClick={() => handleVoiceMessageContact("primary")}
+                        disabled={!primaryEmergencyContactPhone && !primaryEmergencyContactEmail}
+                        className="w-full"
+                      >
+                        <Mic className="mr-2 h-4 w-4" aria-hidden />
+                        Voice
+                      </Button>
+                    </div>
                   </div>
                   <div className="rounded-lg border p-4">
                     <p className="text-xl font-semibold">{secondaryEmergencyContactName}</p>
                     <p className="text-sm text-muted-foreground">
                       {secondaryEmergencyContactPhone || "Add a phone number to enable calling."}
                     </p>
-                    <Button
-                      onClick={() => handleDialEmergencyContact(secondaryEmergencyContactPhone)}
-                      disabled={!secondaryEmergencyContactPhone}
-                      className="mt-3 w-full"
-                    >
-                      Call
-                    </Button>
+                    <div className="mt-3 grid grid-cols-1 gap-2 sm:grid-cols-2">
+                      <Button
+                        onClick={() => handleDialEmergencyContact(secondaryEmergencyContactPhone)}
+                        disabled={!secondaryEmergencyContactPhone}
+                        className="w-full"
+                      >
+                        Call
+                      </Button>
+                      <Button
+                        type="button"
+                        variant="outline"
+                        onClick={() => handleVoiceMessageContact("secondary")}
+                        disabled={!secondaryEmergencyContactPhone && !secondaryEmergencyContactEmail}
+                        className="w-full"
+                      >
+                        <Mic className="mr-2 h-4 w-4" aria-hidden />
+                        Voice
+                      </Button>
+                    </div>
                   </div>
                 </div>
               </CardContent>
             </Card>
 
-            <Card className={`${PRIMARY_CARD_BASE_CLASSES} text-center`}>
+            <Card id="voice-update-card" className={`${PRIMARY_CARD_BASE_CLASSES} text-center`}>
               <CardHeader className={`${PRIMARY_CARD_HEADER_CLASSES} items-center`}>
                 <Mic className="mx-auto h-10 w-10 text-muted-foreground" aria-hidden />
                 <CardTitle className={PRIMARY_CARD_TITLE_CLASSES}>Voice Update</CardTitle>
@@ -1273,7 +1382,11 @@ export default function DashboardPage() {
                 </CardDescription>
               </CardHeader>
               <CardContent className="flex flex-1 flex-col items-center justify-center gap-6 text-center">
-                <VoiceCheckIn onCheckIn={handleCheckIn} />
+                <VoiceCheckIn
+                  onCheckIn={handleVoiceCheckInComplete}
+                  targetContact={voiceMessageTarget}
+                  onClearTarget={() => setVoiceMessageTarget(null)}
+                />
               </CardContent>
             </Card>
           </div>

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -86,12 +86,6 @@ interface UserDoc {
 type Status = "safe" | "missed" | "unknown";
 type LocationShareReason = "sos" | "escalation";
 
-type VoiceMessageTarget = {
-  name: string;
-  email?: string | null;
-  phone?: string | null;
-};
-
 // helper to compute minutes-since-epoch
 const toEpochMinutes = (ms: number) => Math.floor(ms / 60000);
 
@@ -225,9 +219,6 @@ export default function DashboardPage() {
   const [savedPhone, setSavedPhone] = useState<string>("");
   const [phoneDraft, setPhoneDraft] = useState<string>("");
   const [phoneSaving, setPhoneSaving] = useState(false);
-  const [voiceMessageTarget, setVoiceMessageTarget] =
-    useState<VoiceMessageTarget | null>(null);
-
   // 👇 explicit main user UID
   const [mainUserUid, setMainUserUid] = useState<string | null>(null);
 
@@ -954,57 +945,7 @@ export default function DashboardPage() {
 
   const handleVoiceCheckInComplete = useCallback(async () => {
     await handleCheckIn({ showToast: false });
-    setVoiceMessageTarget(null);
   }, [handleCheckIn]);
-
-  const handleVoiceMessageContact = useCallback(
-    (contact: "primary" | "secondary") => {
-      const isPrimary = contact === "primary";
-      const name = isPrimary
-        ? primaryEmergencyContactName
-        : secondaryEmergencyContactName;
-      const phone = isPrimary
-        ? primaryEmergencyContactPhone
-        : secondaryEmergencyContactPhone;
-      const email = isPrimary
-        ? primaryEmergencyContactEmail
-        : secondaryEmergencyContactEmail;
-
-      if (!phone && !email) {
-        toast({
-          title: "Add contact details",
-          description:
-            "Provide a phone number or email to send them a voice message.",
-          variant: "destructive",
-        });
-        return;
-      }
-
-      setVoiceMessageTarget({
-        name,
-        phone: phone || undefined,
-        email: email || undefined,
-      });
-
-      const voiceCard = document.getElementById("voice-update-card");
-      if (voiceCard) {
-        voiceCard.scrollIntoView({ behavior: "smooth", block: "center" });
-        const primaryButton = voiceCard.querySelector<HTMLButtonElement>(
-          'button[data-voice-action="start"]',
-        );
-        primaryButton?.focus({ preventScroll: true });
-      }
-    },
-    [
-      primaryEmergencyContactEmail,
-      primaryEmergencyContactName,
-      primaryEmergencyContactPhone,
-      secondaryEmergencyContactEmail,
-      secondaryEmergencyContactName,
-      secondaryEmergencyContactPhone,
-      toast,
-    ],
-  );
 
   useEffect(() => {
     if (autoCheckInTriggeredRef.current) return;
@@ -1324,23 +1265,13 @@ export default function DashboardPage() {
                     <p className="text-sm text-muted-foreground">
                       {primaryEmergencyContactPhone || "Add a phone number to enable calling."}
                     </p>
-                    <div className="mt-3 grid grid-cols-1 gap-2 sm:grid-cols-2">
+                    <div className="mt-3 grid grid-cols-1 gap-2">
                       <Button
                         onClick={() => handleDialEmergencyContact(primaryEmergencyContactPhone)}
                         disabled={!primaryEmergencyContactPhone}
                         className="w-full"
                       >
                         Call
-                      </Button>
-                      <Button
-                        type="button"
-                        variant="outline"
-                        onClick={() => handleVoiceMessageContact("primary")}
-                        disabled={!primaryEmergencyContactPhone && !primaryEmergencyContactEmail}
-                        className="w-full"
-                      >
-                        <Mic className="mr-2 h-4 w-4" aria-hidden />
-                        Voice
                       </Button>
                     </div>
                   </div>
@@ -1349,23 +1280,13 @@ export default function DashboardPage() {
                     <p className="text-sm text-muted-foreground">
                       {secondaryEmergencyContactPhone || "Add a phone number to enable calling."}
                     </p>
-                    <div className="mt-3 grid grid-cols-1 gap-2 sm:grid-cols-2">
+                    <div className="mt-3 grid grid-cols-1 gap-2">
                       <Button
                         onClick={() => handleDialEmergencyContact(secondaryEmergencyContactPhone)}
                         disabled={!secondaryEmergencyContactPhone}
                         className="w-full"
                       >
                         Call
-                      </Button>
-                      <Button
-                        type="button"
-                        variant="outline"
-                        onClick={() => handleVoiceMessageContact("secondary")}
-                        disabled={!secondaryEmergencyContactPhone && !secondaryEmergencyContactEmail}
-                        className="w-full"
-                      >
-                        <Mic className="mr-2 h-4 w-4" aria-hidden />
-                        Voice
                       </Button>
                     </div>
                   </div>
@@ -1382,11 +1303,7 @@ export default function DashboardPage() {
                 </CardDescription>
               </CardHeader>
               <CardContent className="flex flex-1 flex-col items-center justify-center gap-6 text-center">
-                <VoiceCheckIn
-                  onCheckIn={handleVoiceCheckInComplete}
-                  targetContact={voiceMessageTarget}
-                  onClearTarget={() => setVoiceMessageTarget(null)}
-                />
+                <VoiceCheckIn onCheckIn={handleVoiceCheckInComplete} />
               </CardContent>
             </Card>
           </div>

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -290,7 +290,6 @@ export default function DashboardPage() {
         setSecondaryEmergencyContactName("Emergency Contact 2");
         setSecondaryEmergencyContactPhone(null);
         setSecondaryEmergencyContactEmail(null);
-        setVoiceMessageTarget(null);
         return;
       }
 

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -49,7 +49,7 @@ import { Separator } from "@/components/ui/separator";
 import { useToast } from "@/hooks/use-toast";
 
 // icons
-import { Siren, CheckCircle2, PhoneCall, Clock } from "lucide-react";
+import { Siren, CheckCircle2, PhoneCall, Clock, Mic } from "lucide-react";
 
 // roles
 import { normalizeRole } from "@/lib/roles";
@@ -1229,7 +1229,7 @@ export default function DashboardPage() {
                 <PhoneCall className="mx-auto h-10 w-10 text-muted-foreground" aria-hidden />
                 <CardTitle className={PRIMARY_CARD_TITLE_CLASSES}>Emergency Contacts</CardTitle>
                 <CardDescription className={PRIMARY_CARD_DESCRIPTION_CLASSES}>
-                  Call your emergency contacts instantly or send them a voiced update.
+                  Call your emergency contacts instantly when you need a quick check-in.
                 </CardDescription>
               </CardHeader>
               <CardContent className="flex flex-1 flex-col gap-6">
@@ -1261,16 +1261,19 @@ export default function DashboardPage() {
                     </Button>
                   </div>
                 </div>
+              </CardContent>
+            </Card>
 
-                <Separator className="mx-auto w-24" />
-
-                <div className="flex flex-col items-center gap-4 text-center">
-                  <h3 className="text-2xl font-semibold">Send a voice update</h3>
-                  <p className="max-w-lg text-base text-muted-foreground">
-                    Hold to record a quick message that we analyze and share with your emergency contacts.
-                  </p>
-                  <VoiceCheckIn onCheckIn={handleCheckIn} />
-                </div>
+            <Card className={`${PRIMARY_CARD_BASE_CLASSES} text-center`}>
+              <CardHeader className={`${PRIMARY_CARD_HEADER_CLASSES} items-center`}>
+                <Mic className="mx-auto h-10 w-10 text-muted-foreground" aria-hidden />
+                <CardTitle className={PRIMARY_CARD_TITLE_CLASSES}>Voice Update</CardTitle>
+                <CardDescription className={PRIMARY_CARD_DESCRIPTION_CLASSES}>
+                  Hold to record a quick message that we analyze and share with your emergency contacts.
+                </CardDescription>
+              </CardHeader>
+              <CardContent className="flex flex-1 flex-col items-center justify-center gap-6 text-center">
+                <VoiceCheckIn onCheckIn={handleCheckIn} />
               </CardContent>
             </Card>
           </div>

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1143,60 +1143,69 @@ export default function DashboardPage() {
                     Press the button to check in.
                   </p>
                 </div>
-                <div className="w-full max-w-sm space-y-2 text-left text-base">
-                  <p>
-                    Last Check-in:{" "}
-                    <span className="font-bold text-primary">{formatWhen(lastCheckIn)}</span>
-                  </p>
-                  <p>
-                    Next scheduled check-in:{" "}
-                    <span className="font-bold text-primary">{formatWhen(nextCheckIn)}</span>
-                  </p>
-                  <p>
-                    Countdown:{" "}
-                    <span
-                      className={
-                        status === "missed"
-                          ? "font-bold text-destructive"
-                          : "font-bold text-primary"
-                      }
+              </CardContent>
+            </Card>
+
+            <Card className={`${PRIMARY_CARD_BASE_CLASSES} min-h-0 sm:col-span-2`}>
+              <CardHeader className="space-y-2 text-left">
+                <CardTitle className="text-2xl font-headline">Status Overview</CardTitle>
+                <CardDescription className="text-base">
+                  Keep tabs on your latest check-in and countdown.
+                </CardDescription>
+              </CardHeader>
+              <CardContent>
+                <dl className="grid gap-4 text-base sm:grid-cols-2">
+                  <div className="space-y-1">
+                    <dt className="text-sm text-muted-foreground">Last check-in</dt>
+                    <dd className="text-lg font-semibold text-primary">{formatWhen(lastCheckIn)}</dd>
+                  </div>
+                  <div className="space-y-1">
+                    <dt className="text-sm text-muted-foreground">Next scheduled check-in</dt>
+                    <dd className="text-lg font-semibold text-primary">{formatWhen(nextCheckIn)}</dd>
+                  </div>
+                  <div className="space-y-1">
+                    <dt className="text-sm text-muted-foreground">Countdown</dt>
+                    <dd
+                      className={`text-lg font-semibold ${
+                        status === "missed" ? "text-destructive" : "text-primary"
+                      }`}
                     >
                       {timeLeft || "—"}
-                    </span>
-                  </p>
-                  <p>
-                    Status:{" "}
-                    <span
-                      className={
+                    </dd>
+                  </div>
+                  <div className="space-y-1">
+                    <dt className="text-sm text-muted-foreground">Status</dt>
+                    <dd
+                      className={`text-lg font-semibold ${
                         status === "safe"
-                          ? "font-bold text-green-600"
+                          ? "text-green-600"
                           : status === "missed"
-                          ? "font-bold text-destructive"
-                          : "font-bold text-muted-foreground"
-                      }
+                          ? "text-destructive"
+                          : "text-muted-foreground"
+                      }`}
                     >
                       {status.toUpperCase()}
-                    </span>
-                  </p>
-                  <p className="text-lg">
-                    Location Sharing:{" "}
-                    <span
-                      className={
+                    </dd>
+                  </div>
+                  <div className="space-y-1 sm:col-span-2">
+                    <dt className="text-sm text-muted-foreground">Location sharing</dt>
+                    <dd
+                      className={`text-lg font-semibold ${
                         locationSharing === true
-                          ? "font-bold text-green-600"
+                          ? "text-green-600"
                           : locationSharing === false
-                          ? "font-bold text-destructive"
-                          : "font-bold text-muted-foreground"
-                      }
+                          ? "text-destructive"
+                          : "text-muted-foreground"
+                      }`}
                     >
                       {locationSharing === null
                         ? "—"
                         : locationSharing
                         ? "Enabled"
                         : "Disabled"}
-                    </span>
-                  </p>
-                </div>
+                    </dd>
+                  </div>
+                </dl>
               </CardContent>
             </Card>
 


### PR DESCRIPTION
## Summary
- extract the dashboard status details into a dedicated "Status Overview" card
- keep the check-in card focused on the action button while preserving existing styling
- present status metrics in a responsive definition list for improved readability

## Testing
- `npm run lint` *(fails: next not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ebd81a2bcc83239dcd16ffb4d9ba15