### PR TITLE
Update emergency contact invite email to point to signup flow

### DIFF
--- a/src/app/api/emergency_contact/invite/resend/route.ts
+++ b/src/app/api/emergency_contact/invite/resend/route.ts
@@ -171,13 +171,14 @@ export async function POST(req: NextRequest) {
 
     // Build the acceptance URL
     const origin = getOrigin(req);
-    const acceptUrl = `${origin}/emergency_contact/accept?invite=${inviteRef.id}&token=${token}`;
+    const acceptPath = `/signup?role=emergency_contact&token=${token}`;
+    const acceptUrl = `${origin}${acceptPath}`;
 
     /**
      * Optional: If you enforce verified email before acceptance,
      * send them to /verify-email first, then continue to acceptUrl.
      */
-    const verifyContinue = `${origin}/verify-email?next=${encodeURIComponent(acceptUrl)}`;
+    const verifyContinue = `${origin}/verify-email?next=${encodeURIComponent(acceptPath)}`;
 
     // Send the email using your /mail collection (Firebase Ext or your mail worker)
     await db.collection("mail").add({

--- a/src/app/api/emergency_contact/invite/route.ts
+++ b/src/app/api/emergency_contact/invite/route.ts
@@ -189,13 +189,14 @@ export async function POST(req: NextRequest) {
 
     // Build the acceptance URL
     const origin = getOrigin(req);
-    const acceptUrl = `${origin}/emergency_contact/accept?invite=${inviteRef.id}&token=${token}`;
+    const acceptPath = `/signup?role=emergency_contact&token=${token}`;
+    const acceptUrl = `${origin}${acceptPath}`;
 
     /**
      * Optional: If you enforce verified email before acceptance,
      * send them to /verify-email first, then continue to acceptUrl.
      */
-    const verifyContinue = `${origin}/verify-email?next=${encodeURIComponent(acceptUrl)}`;
+    const verifyContinue = `${origin}/verify-email?next=${encodeURIComponent(acceptPath)}`;
 
     // Send the email using your /mail collection (Firebase Ext or your mail worker)
     await db.collection("mail").add({


### PR DESCRIPTION
## Summary
- update emergency contact invite and resend APIs to build signup URLs for invitees
- keep verify-email continuation paths aligned with the new signup destination while still returning absolute links for emails

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ec2460de08832381074bcc92e3d853