### PR TITLE
Fix targeted voice messages leaking to all contacts

### DIFF
--- a/src/app/api/voice-check-in/notify/route.ts
+++ b/src/app/api/voice-check-in/notify/route.ts
@@ -154,6 +154,10 @@ export async function POST(req: NextRequest) {
       createdAt: FieldValue.serverTimestamp(),
       expiresAt,
       audioDataUrl: audioDataUrl ?? null,
+      audience: "broadcast" as const,
+      targetEmergencyContactUid: null,
+      targetEmergencyContactEmail: null,
+      targetEmergencyContactPhone: null,
     };
 
     // 5) Write once to the main user + mirror onto every ACTIVE contact doc.


### PR DESCRIPTION
## Summary
- mark broadcast voice payloads with an explicit audience
- tag targeted voice messages with the intended emergency contact and mirror them only to that contact
- hide targeted voice updates from other emergency contacts on the emergency dashboard

## Testing
- npm run lint *(fails: `next` binary not available in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68f456f8b09483239866f4faa615b233