### PR TITLE
Fix emergency dashboard Firestore link collection query

### DIFF
--- a/src/app/api/emergency_contact/legacy-links/route.ts
+++ b/src/app/api/emergency_contact/legacy-links/route.ts
@@ -1,0 +1,55 @@
+export const runtime = "nodejs";
+
+import { NextRequest, NextResponse } from "next/server";
+
+import { adminAuth, db } from "@/lib/firebaseAdmin";
+
+async function requireEmergencyContact(req: NextRequest) {
+  const cookie = req.cookies.get("__session")?.value || "";
+  if (!cookie) {
+    throw new Error("UNAUTHENTICATED");
+  }
+
+  try {
+    const decoded = await adminAuth.verifySessionCookie(cookie, true);
+    return { uid: decoded.uid as string };
+  } catch {
+    throw new Error("UNAUTHENTICATED");
+  }
+}
+
+export async function GET(req: NextRequest) {
+  try {
+    const { uid } = await requireEmergencyContact(req);
+
+    const snapshot = await db
+      .collection("emergencyContacts")
+      .where("emergencyContactUid", "==", uid)
+      .get();
+
+    const mainUserUids = new Set<string>();
+
+    snapshot.forEach((docSnap) => {
+      const data = docSnap.data() as any;
+      const canonical =
+        typeof data?.mainUserUid === "string" ? data.mainUserUid.trim() : "";
+      const legacy =
+        typeof data?.mainUserId === "string" ? data.mainUserId.trim() : "";
+
+      if (canonical) mainUserUids.add(canonical);
+      else if (legacy) mainUserUids.add(legacy);
+    });
+
+    return NextResponse.json({ mainUserUids: Array.from(mainUserUids) });
+  } catch (error: any) {
+    if (error?.message === "UNAUTHENTICATED") {
+      return NextResponse.json({ error: "Unauthenticated" }, { status: 401 });
+    }
+
+    console.error("[legacy-links] Unexpected error", error);
+    return NextResponse.json(
+      { error: "Unable to load legacy links" },
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/emergency-dashboard/page.tsx
+++ b/src/app/emergency-dashboard/page.tsx
@@ -16,6 +16,7 @@ import {
   doc,
   getDoc,
   Timestamp,
+  documentId,
   type Unsubscribe,
   type Query as FsQuery,
   type QuerySnapshot,
@@ -371,10 +372,10 @@ export default function EmergencyDashboardPage() {
       setEmergencyContactUid(user.uid);
       setLoading(false);
 
-      // users/{mainUserUid}/emergency_contact/{linkDoc} where emergencyContactUid == current user.uid
+      // users/{mainUserUid}/emergency_contact/{linkDoc} where doc id == current user uid
       const linksByEmergencyContactUid = query(
         collectionGroup(db, "emergency_contact"),
-        where("emergencyContactUid", "==", user.uid),
+        where(documentId(), "==", user.uid),
       );
 
       function wireLinksListener(q: FsQuery<DocumentData>, key: string) {

--- a/src/app/emergency-dashboard/page.tsx
+++ b/src/app/emergency-dashboard/page.tsx
@@ -371,9 +371,9 @@ export default function EmergencyDashboardPage() {
       setEmergencyContactUid(user.uid);
       setLoading(false);
 
-      // users/{mainUserUid}/emergency-contact/{linkDoc} where emergencyContactUid == current user.uid
+      // users/{mainUserUid}/emergency_contact/{linkDoc} where emergencyContactUid == current user.uid
       const linksByEmergencyContactUid = query(
-        collectionGroup(db, "emergency-contact"),
+        collectionGroup(db, "emergency_contact"),
         where("emergencyContactUid", "==", user.uid),
       );
 


### PR DESCRIPTION
## Summary
- correct the emergency dashboard Firestore collectionGroup query to match the stored link collection name

## Testing
- npm run lint *(fails: next command not found in CI sandbox)*

------
https://chatgpt.com/codex/tasks/task_e_6907492d09a48323b3b0ce65140b3775