### PR TITLE
Notify main user on missed check-in

### DIFF
--- a/docs/blueprint.md
+++ b/docs/blueprint.md
@@ -10,6 +10,12 @@
 - Record Voice Check-in: Allow the user to record an 'I'm OK' message and store it.
 - AI Voice Check-in Assessment: A tool that uses voice recognition and an LLM to evaluate the transcribed user speech and compare it to previously stored voice messages in order to verify user's condition based on behavioral biometrics such as speech rate, cadence, and typical phrases.
 
+## Check-in notification cadence
+
+- The scheduled escalation job runs every 5 minutes to look for overdue check-ins and start the notification workflow.
+- A check-in is considered overdue when the time since `lastCheckinAt` exceeds the user's configured `checkinInterval` (default 60 minutes).
+- Once a missed check-in notification goes out, the system waits at least 10 minutes before sending any further missed-check-in push notifications for that user, preventing rapid repeats.
+
 ## Style Guidelines:
 
 - Primary color: Soft blue (#64B5F6) for a calm and reassuring feel.

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -529,6 +529,21 @@ async function runEscalationScanJob(input: { cooldownMin?: number } = {}) {
         `${u.firstName || ""} ${u.lastName || ""}`.trim() :
         "a user";
 
+    // Notify the main user that they missed their check-in (best-effort)
+    try {
+      const mainUserTokens = await getFcmTokensForUser(mainUserUid);
+      await sendPushToTokens(
+        mainUserTokens,
+        {
+          title: "Life Signal: missed check-in",
+          body: "You missed your check-in. Please open the app to confirm you are safe.",
+        },
+        { type: "missed_checkin_main_user", mainUserUid }
+      );
+    } catch (e) {
+      logger.warn("Main user push failed (non-fatal)", (e as any)?.message);
+    }
+
     if (policy.mode === "call_immediately") {
       // (Optional) Push to ECs informing a call is being placed now
       try {


### PR DESCRIPTION
## Summary
- send the missed check-in push notification to the main user's devices as well as emergency contacts
- include a main-user-specific payload to prompt them to open the app and confirm safety

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6923adb74b2c8323b57e78f8471cb568)